### PR TITLE
Minor improvements (path checking and perf) to module startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function fastifyStatic (fastify, opts, next) {
   const serve500 = servePathWithStatusCodeWrapper(page500, 500)
 
   function pumpSendToReply (req, reply, pathname) {
-    const sendStream = send(req, pathname, {root})
+    const sendStream = send(req, pathname, { root })
 
     sendStream.on('error', function (err) {
       if (err.statusCode === 404) return serve404(req, reply.res)
@@ -49,6 +49,7 @@ function fastifyStatic (fastify, opts, next) {
 
   if (opts.prefix === undefined) opts.prefix = '/'
   const prefix = opts.prefix[opts.prefix.length - 1] === '/' ? opts.prefix : (opts.prefix + '/')
+
   fastify.get(prefix + '*', function (req, reply) {
     pumpSendToReply(req.req, reply, '/' + req.params['*'])
   })
@@ -82,7 +83,7 @@ function checkRootPath (rootPath) {
   }
 
   if (rootStat.isDirectory() === false) {
-    return new Error('"root" option must be an absolute path')
+    return new Error('"root" option must point to a directory')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -73,32 +73,27 @@ function fastifyStatic (fastify, opts, next) {
 function checkPathsForErrors (paths) {
   if (paths.root === undefined) return new Error('"root" option is required')
 
-  for (const p in paths) {
-    if (paths[p] !== undefined) {
-      if (typeof paths[p] !== 'string') {
-        return new Error(`"${p}" option must be a string`)
-      }
+  checkPath(paths.root, 'root', 'isDirectory')
+  if (paths.page500Path !== undefined) checkPath(paths.page500Path, 'page500Path', 'isFile')
+  if (paths.page403Path !== undefined) checkPath(paths.page403Path, 'page403Path', 'isFile')
+  if (paths.page404Path !== undefined) checkPath(paths.page404Path, 'page404Path', 'isFile')
+}
 
-      if (path.isAbsolute(paths[p]) === false) {
-        return new Error(`"${p}" option must be an absolute path`)
-      }
+function checkPath (p, pathName, statMethod) {
+  if (typeof p !== 'string') return new Error(`"${pathName}" option must be a string`)
 
-      let pathStat
+  if (path.isAbsolute(p) === false) return new Error(`"${pathName}" option must be an absolute path`)
 
-      try {
-        pathStat = statSync(paths[p])
-      } catch (e) {
-        return e
-      }
+  let pathStat
 
-      if (p === 'root' && pathStat.isDirectory() === false) {
-        return new Error('"root" option must point to a directory')
-      }
+  try {
+    pathStat = statSync(p)
+  } catch (e) {
+    return e
+  }
 
-      if (p !== 'root' && pathStat.isFile() === false) {
-        return new Error(`"${p}" option must point to a file`)
-      }
-    }
+  if (pathStat[statMethod]() === false) {
+    return new Error(`${pathName} option must point to a ${statMethod.slice(2).toLowerCase()}`)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function fastifyStatic (fastify, opts, next) {
     sendStream.pipe(reply.res)
   }
 
-  if (!opts.prefix) opts.prefix = '/'
+  if (opts.prefix === undefined) opts.prefix = '/'
   const prefix = opts.prefix[opts.prefix.length - 1] === '/' ? opts.prefix : (opts.prefix + '/')
   fastify.get(prefix + '*', function (req, reply) {
     pumpSendToReply(req.req, reply, '/' + req.params['*'])
@@ -68,7 +68,7 @@ function checkOptions (opts) {
   if (typeof opts.root !== 'string') {
     return new Error('"root" option is required')
   }
-  if (!path.isAbsolute(opts.root)) {
+  if (path.isAbsolute(opts.root) === false) {
     return new Error('"root" option must be an absolute path')
   }
   let rootStat
@@ -77,7 +77,7 @@ function checkOptions (opts) {
   } catch (e) {
     return e
   }
-  if (!rootStat.isDirectory()) {
+  if (rootStat.isDirectory() === false) {
     return new Error('"root" option must be an absolute path')
   }
 }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const DEFAULT_403_PAGE = path.join(__dirname, 'static', '403.html')
 const DEFAULT_404_PAGE = path.join(__dirname, 'static', '404.html')
 
 function fastifyStatic (fastify, opts, next) {
-  const error = checkOptions(opts)
+  const error = checkRootPath(opts.root)
   if (error instanceof Error) return next(error)
 
   const root = opts.root
@@ -64,19 +64,23 @@ function fastifyStatic (fastify, opts, next) {
   next()
 }
 
-function checkOptions (opts) {
-  if (typeof opts.root !== 'string') {
+function checkRootPath (rootPath) {
+  if (typeof rootPath !== 'string') {
     return new Error('"root" option is required')
   }
-  if (path.isAbsolute(opts.root) === false) {
+
+  if (path.isAbsolute(rootPath) === false) {
     return new Error('"root" option must be an absolute path')
   }
+
   let rootStat
+
   try {
-    rootStat = statSync(opts.root)
+    rootStat = statSync(rootPath)
   } catch (e) {
     return e
   }
+
   if (rootStat.isDirectory() === false) {
     return new Error('"root" option must be an absolute path')
   }

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ const DEFAULT_403_PAGE = path.join(__dirname, 'static', '403.html')
 const DEFAULT_404_PAGE = path.join(__dirname, 'static', '404.html')
 
 function fastifyStatic (fastify, opts, next) {
-  const error = checkRootPath(opts.root)
-  if (error instanceof Error) return next(error)
+  const error = checkRootPathForErrors(opts.root)
+  if (error !== undefined) return next(error)
 
   const root = opts.root
   const page500 = opts.page500Path || DEFAULT_500_PAGE
@@ -65,7 +65,7 @@ function fastifyStatic (fastify, opts, next) {
   next()
 }
 
-function checkRootPath (rootPath) {
+function checkRootPathForErrors (rootPath) {
   if (typeof rootPath !== 'string') {
     return new Error('"root" option is required')
   }


### PR DESCRIPTION
- Minor perf improvements
  + Use strict equality in place of truthiness checks
  + [Check `error` against `undefined`](https://github.com/fastify/fastify-static/compare/master...gj:minor-perf-improvements?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR16) instead of relying on the slower `instanceof` operator. Also rename function to mitigate the decrease in self-documentation by moving away from `error instanceof Error`
- Clean up code
  + Rename `checkOptions()` since it's only checking the validity of the root path
  + ~Destructure objects to reduce redundant code~
  + [Improve error message](https://github.com/fastify/fastify-static/compare/master...gj:minor-perf-improvements?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR86) for when the `root` option doesn't point to a directory

ETA: Test coverage remains at :100:

ETA2: Forgot object destructuring isn't available in Node 4.x