### PR TITLE
Forward errors to Fastify instead of sending custom error pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,17 @@ The following options are also supported and will be passed directly to the
 - [`lastModified`](https://www.npmjs.com/package/send#lastmodified)
 - [`maxAge`](https://www.npmjs.com/package/send#maxage)
 
+#### Handling 404s
+
+If a request matches the URL `prefix` but a file cannot be found for the
+request, Fastify's 404 handler will be called. You can set a custom 404
+handler with [`fastify.setNotFoundHandler()`](https://www.fastify.io/docs/latest/Server-Methods/#setnotfoundhandler).
+
 ### Handling Errors
 
 If an error occurs while trying to send a file, the error will be passed
 to Fastify's error handler. You can set a custom error handler with
 [`fastify.setErrorHandler()`](https://www.fastify.io/docs/latest/Server-Methods/#seterrorhandler).
-
-If a request matches the URL `prefix` but a file cannot be found for the request,
-a `404 Not Found` error will be created and passed to Fastify's error handler.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ fastify.get('/another/path', function (req, reply) {
 
 ```
 
-Any errors that occur (including `404` errors) will be passed to
-Fastify's error handler. You can set a custom error handler with
-[`fastify.setErrorHandler()`](https://www.fastify.io/docs/latest/Server-Methods/#seterrorhandler).
-
 ### Options
 
 #### `root` (required)
@@ -68,6 +64,15 @@ The following options are also supported and will be passed directly to the
 - [`index`](https://www.npmjs.com/package/send#index)
 - [`lastModified`](https://www.npmjs.com/package/send#lastmodified)
 - [`maxAge`](https://www.npmjs.com/package/send#maxage)
+
+### Handling Errors
+
+If an error occurs while trying to send a file, the error will be passed
+to Fastify's error handler. You can set a custom error handler with
+[`fastify.setErrorHandler()`](https://www.fastify.io/docs/latest/Server-Methods/#seterrorhandler).
+
+If a request matches the URL `prefix` but a file cannot be found for the request,
+a `404 Not Found` error will be created and passed to Fastify's error handler.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ const path = require('path')
 fastify.register(require('fastify-static'), {
   root: path.join(__dirname, 'public'),
   prefix: '/public/', // optional: default '/'
-  page404Path: path.join(__dirname, 'public', '404.html'), // optional
-  page403Path: path.join(__dirname, 'public', '403.html'), // optional
-  page500Path: path.join(__dirname, 'public', '500.html')  // optional
 })
 
 fastify.get('/another/path', function (req, reply) {
@@ -26,6 +23,10 @@ fastify.get('/another/path', function (req, reply) {
 })
 
 ```
+
+Any errors that occur (including `404` errors) will be passed to
+Fastify's error handler. You can set a custom error handler with
+[`fastify.setErrorHandler()`](https://www.fastify.io/docs/latest/Server-Methods/#seterrorhandler).
 
 ### Options
 
@@ -40,11 +41,6 @@ provided root directory.
 Default: `'/'`
 
 A URL path prefix used to create a virtual mount path for the static directory.
-
-#### `page404Path`, `page403Path`, `page500Path`
-
-The absolute path to an HTML file to send as a response for the corresponding
-error status code. A generic error page is sent by default.
 
 #### `setHeaders`
 

--- a/static/403.html
+++ b/static/403.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Error</title>
-</head>
-<body>
-<pre>Forbidden</pre>
-</body>

--- a/static/404.html
+++ b/static/404.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Error</title>
-</head>
-<body>
-<pre>Not Found</pre>
-</body>

--- a/static/500.html
+++ b/static/500.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Error</title>
-</head>
-<body>
-<pre>Internal Error</pre>
-</body>


### PR DESCRIPTION
Fixes #17 

@mcollina I hope this is what you meant as the solution to #17. Let me know if it isn't. ~~I couldn't find any way to handle 404s with `setNotFoundHandler` so I made it clear in the docs that 404 errors will be passed to Fastify's error handler.~~