### PR TITLE
Expose filename to output stream.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ If an error occurs while trying to send a file, the error will be passed
 to Fastify's error handler. You can set a custom error handler with
 [`fastify.setErrorHandler()`](https://www.fastify.io/docs/latest/Server-Methods/#seterrorhandler).
 
+### Payload `stream.filename`
+
+If you need to access the filename inside the `onSend` hook, you can use `payload.filename`.
+
+```js
+fastify.addHook('onSend', function (req, reply, payload, next) {
+  console.log(payload.filename)
+  next()
+})
+```
+
 ## License
 
 Licensed under [MIT](./LICENSE)


### PR DESCRIPTION
I'm working on a fastify-babel module which will hook `onSend` and run Javascript through babel.  I'm doing this so I can use `npm start` to serve files which can use bare imports such as `import {PolymerElement} from "@polymer/polymer";'.  I have a babel plugin (not yet published) which translates bare imports to be browser compatible.  This babel plugin requires knowledge of the filename being processed so it can properly resolve the import.  I'd like to avoid duplicating codes from fastify-static (either using `send` myself or reimplementing URL to local filename resolution).