### PR TITLE
Create decorateReply option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ The following options are also supported and will be passed directly to the
 - [`lastModified`](https://www.npmjs.com/package/send#lastmodified)
 - [`maxAge`](https://www.npmjs.com/package/send#maxage)
 
+#### Disabling reply decorator
+
+The reply object is decorated with a `sendFile` function by default.  If you want to
+disable this, pass the option `{ decorateReply: false }`.  If fastify-static is
+registers to multiple prefixes in the same route only one can initialize reply
+decorators.
+
 #### Handling 404s
 
 If a request matches the URL `prefix` but a file cannot be found for the

--- a/index.js
+++ b/index.js
@@ -86,9 +86,11 @@ function fastifyStatic (fastify, opts, next) {
     pumpSendToReply(req, reply, '/' + req.params['*'])
   })
 
-  fastify.decorateReply('sendFile', function (filePath) {
-    pumpSendToReply(this.request, this, filePath)
-  })
+  if (opts.decorateReply !== false) {
+    fastify.decorateReply('sendFile', function (filePath) {
+      pumpSendToReply(this.request, this, filePath)
+    })
+  }
 
   next()
 }

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -417,6 +417,45 @@ t.test('sendFile', t => {
   })
 })
 
+t.test('sendFile disabled', t => {
+  t.plan(2)
+
+  const pluginOptions = {
+    root: path.join(__dirname, '/static'),
+    prefix: '/static',
+    decorateReply: false
+  }
+  const fastify = Fastify()
+  fastify.register(fastifyStatic, pluginOptions)
+
+  fastify.get('/foo/bar', function (req, reply) {
+    if (typeof reply.sendFile === 'undefined') {
+      reply.send('pass')
+    } else {
+      reply.send('fail')
+    }
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    fastify.server.unref()
+
+    t.test('reply.sendFile undefined', t => {
+      t.plan(3)
+      simple.concat({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port + '/foo/bar',
+        followRedirect: false
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.strictEqual(body.toString(), 'pass')
+      })
+    })
+  })
+})
+
 t.test('prefix default', t => {
   t.plan(1)
   const pluginOptions = {root: path.join(__dirname, 'static')}


### PR DESCRIPTION
This option allows fastify-static to be registered without decorating
the reply object.  This is needed when registering multiple static
prefixes to a single route.

Fixes #62