### PR TITLE
Log warning if root directory does not exist instead of throwing error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const send = require('send')
 const fp = require('fastify-plugin')
 
 function fastifyStatic (fastify, opts, next) {
-  const error = checkRootPathForErrors(opts.root)
+  const error = checkRootPathForErrors(fastify, opts.root)
   if (error !== undefined) return next(error)
 
   const setHeaders = opts.setHeaders
@@ -163,7 +163,7 @@ function fastifyStatic (fastify, opts, next) {
   next()
 }
 
-function checkRootPathForErrors (rootPath) {
+function checkRootPathForErrors (fastify, rootPath) {
   if (rootPath === undefined) {
     return new Error('"root" option is required')
   }
@@ -180,7 +180,8 @@ function checkRootPathForErrors (rootPath) {
     pathStat = statSync(rootPath)
   } catch (e) {
     if (e.code === 'ENOENT') {
-      return new Error(`"root" path "${rootPath}" must exist`)
+      fastify.log.warn(`"root" path "${rootPath}" must exist`)
+      return
     }
 
     return e

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@types/node": "^10.12.27",
+    "concat-stream": "^2.0.0",
     "coveralls": "^3.0.3",
     "eslint-plugin-typescript": "^0.14.0",
     "fastify": "^2.0.0",


### PR DESCRIPTION
It is still an error of the root path exists but is not a directory.

Fixes #101