### PR TITLE
fix: handle missing trailing slash on directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ If set to `true`, `fastify-static` redirects to the directory with a trailing sl
 This option cannot be set to `true` with `wildcard` set to `false` on a server
 with `ignoreTrailingSlash` set to `true`.
 
+If this option is set to `false`, then requesting directories without trailing 
+slash will trigger your app's 404 handler using `reply.callNotFound()`.
+
 #### `wildcard`
 
 Default: `true`

--- a/index.js
+++ b/index.js
@@ -77,12 +77,14 @@ function fastifyStatic (fastify, opts, next) {
       stream.on('headers', setHeaders)
     }
 
-    if (opts.redirect === true) {
-      stream.on('directory', function (res, path) {
+    stream.on('directory', function (res, path) {
+      if (opts.redirect === true) {
         const parsed = url.parse(request.raw.url)
         reply.redirect(301, parsed.pathname + '/' + (parsed.search || ''))
-      })
-    }
+      } else {
+        reply.callNotFound()
+      }
+    })
 
     stream.on('error', function (err) {
       if (err) {

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1850,3 +1850,78 @@ t.test('register /static with redirect true and wildcard false', t => {
     })
   })
 })
+
+t.test('trailing slash behavior with redirect = false', t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+  fastify.register(fastifyStatic, {
+    root: path.join(__dirname, '/static'),
+    prefix: '/static',
+    redirect: false
+  })
+  fastify.server.unref()
+
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    const host = 'http://localhost:' + fastify.server.address().port
+
+    t.test('prefix with no trailing slash => 404', t => {
+      t.plan(2)
+      simple.concat({
+        method: 'GET',
+        url: host + '/static'
+      }, (err, response) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 404)
+      })
+    })
+
+    t.test('prefix with trailing trailing slash => 200', t => {
+      t.plan(2)
+      simple.concat({
+        method: 'GET',
+        url: host + '/static/'
+      }, (err, response) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+      })
+    })
+
+    t.test('deep path with no index.html or trailing slash => 404', t => {
+      t.plan(2)
+      simple.concat({
+        method: 'GET',
+        url: host + '/static/deep/path'
+      }, (err, response) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 404)
+      })
+    })
+
+    t.test('deep path with index.html but no trailing slash => 404', t => {
+      t.plan(2)
+      simple.concat({
+        method: 'GET',
+        url: host + '/static/deep/path/for/test'
+      }, (err, response) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 404)
+      })
+    })
+
+    t.test('deep path with index.html and trailing slash => 200', t => {
+      t.plan(2)
+      simple.concat({
+        method: 'GET',
+        url: host + '/static/deep/path/for/test/'
+      }, (err, response) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Currently, when fastify-static is configured with `redirect` option set to `false` and a request for a directory does not contain a trailing slash, it causes the server to hang. This is because we only register a directory handler on the underlying `send` stream if `redirect` option is `true`.

This PR updates the library to handle such requests by calling `reply.callNotFound()`. We presume that requesting a directory without using a trailing slash OR setting `redirect` to `true` should be handled explicitly as a 404.

To reproduce the bug:

```js
const path = require('path')
const Fastify = require('fastify')
const fastifyStatic = require('fastify-static')

const fastify = Fastify()
fastify.register(fastifyStatic, {
  // using the fixture in fastify-static's test folder
  root: path.join(__dirname, '/test/static'),
  redirect: false
})

fastify.listen(3000, () => {
  console.log('ready')
})
```

In another terminal, running the following command will hang indefinitely:

```
curl http://localhost:3000/deep/path/for/test
```


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
