### PR TITLE
fix for typescript http2/https warning

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // Definitions by: Jannik <https://github.com/jannikkeye>
 //                 Leo <https://github.com/leomelzer>
 /// <reference types="node" />
-import fastify, { FastifyRequest, DefaultQuery, Plugin } from "fastify";
+import fastify, { Plugin } from "fastify";
 import { Server, IncomingMessage, ServerResponse } from "http";
 import { Http2SecureServer, Http2Server, Http2ServerRequest, Http2ServerResponse } from "http2";
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,9 @@ import * as fastify from 'fastify';
 import { Plugin } from "fastify";
 import { Server, IncomingMessage, ServerResponse } from "http";
 import { Http2SecureServer, Http2Server, Http2ServerRequest, Http2ServerResponse } from "http2";
+import * as https from "https";
 
-type HttpServer = Server | Http2Server | Http2SecureServer;
+type HttpServer = Server | Http2Server | Http2SecureServer | https.Server;
 type HttpRequest = IncomingMessage | Http2ServerRequest;
 type HttpResponse = ServerResponse | Http2ServerResponse;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,25 @@
 // Definitions by: Jannik <https://github.com/jannikkeye>
 //                 Leo <https://github.com/leomelzer>
-
-import fastify = require("fastify");
-
+/// <reference types="node" />
+import fastify, { FastifyRequest, DefaultQuery, Plugin } from "fastify";
 import { Server, IncomingMessage, ServerResponse } from "http";
+import { Http2SecureServer, Http2Server, Http2ServerRequest, Http2ServerResponse } from "http2";
+
+type HttpServer = Server | Http2Server | Http2SecureServer;
+type HttpRequest = IncomingMessage | Http2ServerRequest;
+type HttpResponse = ServerResponse | Http2ServerResponse;
 
 declare module "fastify" {
-    interface FastifyReply<HttpResponse> {
-        sendFile(filename: string): FastifyReply<HttpResponse>;
-    }
+  interface FastifyReply<HttpResponse> {
+    sendFile(filename: string): FastifyReply<HttpResponse>;
+  }
 }
 
-declare const fastifyStatic: fastify.Plugin<Server, IncomingMessage, ServerResponse, {
+declare function fastifyStatic(): fastify.Plugin<
+  Server,
+  IncomingMessage,
+  ServerResponse,
+  {
     root: string;
     prefix?: string;
     serve?: boolean;
@@ -31,6 +39,11 @@ declare const fastifyStatic: fastify.Plugin<Server, IncomingMessage, ServerRespo
     index?: string[];
     lastModified?: boolean;
     maxAge?: string | number;
-}>;
+  }
+>;
+
+declare namespace fastifyStatic {
+  interface FastifyStaticOptions {}
+}
 
 export = fastifyStatic;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
 // Definitions by: Jannik <https://github.com/jannikkeye>
 //                 Leo <https://github.com/leomelzer>
 /// <reference types="node" />
-import fastify, { Plugin } from "fastify";
+import * as fastify from 'fastify';
+import { Plugin } from "fastify";
 import { Server, IncomingMessage, ServerResponse } from "http";
 import { Http2SecureServer, Http2Server, Http2ServerRequest, Http2ServerResponse } from "http2";
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,9 +1,11 @@
-import * as Fastify from 'fastify'
+import * as fastify from 'fastify'
+import * as http2 from 'http2'
 import * as fastifyStatic from '../..'
 
-const app = Fastify()
+console.log(http2.constants.NGHTTP2_NO_ERROR) // fix for http2 is declared but not used
 
-app.register(fastifyStatic, {
+const appWithImplicitHttp = fastify()
+const options = {
   acceptRanges: true,
   cacheControl: true,
   decorateReply: true,
@@ -22,8 +24,26 @@ app.register(fastifyStatic, {
   setHeaders: (res: any, pathName: any) => {
     res.setHeader('test', pathName)
   }
-})
+}
 
-app.get('/file', (request, reply) => {
-  reply.sendFile('some-file-name')
-})
+appWithImplicitHttp
+  .register(fastifyStatic, options)
+  .after(() => {
+    appWithImplicitHttp.get('/', (request, reply) => {
+      reply.sendFile('some-file-name')
+    })
+  })
+
+const appWithHttp2: fastify.FastifyInstance<
+  http2.Http2Server,
+  http2.Http2ServerRequest,
+  http2.Http2ServerResponse
+> = fastify({ http2: true })
+
+appWithHttp2
+  .register(fastifyStatic, options)
+  .after(() => {
+    appWithHttp2.get('/', (request, reply) => {
+      reply.sendFile('some-file-name')
+    })
+  })


### PR DESCRIPTION
Fix for #114 

I'm not an expert in typescript and declaration files, but i was able to adapt fastify-static declaration file in style of fastify-cookie declaration file (that gives no typescript warnings).

Now it should compile without problems for http2 and htpps too.

Checked on my own server with http, http2 and https settings for server.