### PR TITLE
Add rootPath overload parameter to sendFile function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ fastify.get('/another/path', function (req, reply) {
   reply.sendFile('myHtml.html') // serving path.join(__dirname, 'public', 'myHtml.html') directly
 })
 
+fastify.get('/path/with/different/root', function (req, reply) {
+  reply.sendFile('myHtml.html', path.join(__dirname, 'build')) // serving a file from a different root location
+})
+
 ```
 
 ### Options

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ type HttpResponse = ServerResponse | Http2ServerResponse;
 
 declare module "fastify" {
   interface FastifyReply<HttpResponse> {
-    sendFile(filename: string): FastifyReply<HttpResponse>;
+    sendFile(filename: string, rootPath?: string): FastifyReply<HttpResponse>;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -33,8 +33,14 @@ function fastifyStatic (fastify, opts, next) {
     maxAge: opts.maxAge
   }
 
-  function pumpSendToReply (request, reply, pathname) {
-    const stream = send(request.raw, pathname, sendOptions)
+  function pumpSendToReply (request, reply, pathname, rootPath) {
+    var options = Object.assign({}, sendOptions)
+
+    if (rootPath) {
+      options.root = rootPath
+    }
+
+    const stream = send(request.raw, pathname, options)
     var resolvedFilename
     stream.on('file', function (file) {
       resolvedFilename = file
@@ -106,8 +112,8 @@ function fastifyStatic (fastify, opts, next) {
   const schema = { schema: { hide: typeof opts.schemaHide !== 'undefined' ? opts.schemaHide : true } }
 
   if (opts.decorateReply !== false) {
-    fastify.decorateReply('sendFile', function (filePath) {
-      pumpSendToReply(this.request, this, filePath)
+    fastify.decorateReply('sendFile', function (filePath, rootPath) {
+      pumpSendToReply(this.request, this, filePath, rootPath)
     })
   }
 


### PR DESCRIPTION
For my project the root path is user configurable and can be changed without a server restart, so I needed a way to specify the path dynamically when a file is requested.

This change also allows files to be served from more than one root path