### PR TITLE
fastify v3 deprecated reply.res

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function fastifyStatic (fastify, opts, next) {
     const wrap = new PassThrough({
       flush (cb) {
         this.finished = true
-        if (reply.res.statusCode === 304) {
+        if ((reply.raw || reply.res).statusCode === 304) {
           reply.send('')
         }
         cb()
@@ -68,7 +68,7 @@ function fastifyStatic (fastify, opts, next) {
     })
     Object.defineProperty(wrap, 'statusCode', {
       get () {
-        return reply.res.statusCode
+        return (reply.raw || reply.res).statusCode
       },
       set (code) {
         reply.code(code)


### PR DESCRIPTION
https://github.com/fastify/fastify/blob/master/docs/Migration-Guide-V3.md#further-additions-and-improvements
`Deprecated request.req and reply.res for request.raw and reply.raw`
