### PR TITLE
thenable bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ fastify.register(require('fastify-static'), {
 })
 
 fastify.get('/another/path', function (req, reply) {
-  reply.sendFile('myHtml.html') // serving path.join(__dirname, 'public', 'myHtml.html') directly
+  return reply.sendFile('myHtml.html') // serving path.join(__dirname, 'public', 'myHtml.html') directly
 })
 
 fastify.get('/path/with/different/root', function (req, reply) {
-  reply.sendFile('myHtml.html', path.join(__dirname, 'build')) // serving a file from a different root location
+  return reply.sendFile('myHtml.html', path.join(__dirname, 'build')) // serving a file from a different root location
 })
 
 ```

--- a/index.js
+++ b/index.js
@@ -134,6 +134,7 @@ function fastifyStatic (fastify, opts, next) {
   if (opts.decorateReply !== false) {
     fastify.decorateReply('sendFile', function (filePath, rootPath) {
       pumpSendToReply(this.request, this, filePath, rootPath)
+      return this
     })
   }
 

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -627,7 +627,7 @@ t.test('serving disabled', t => {
   fastify.register(fastifyStatic, pluginOptions)
 
   fastify.get('/foo/bar', (request, reply) => {
-    reply.sendFile('index.html')
+    return reply.sendFile('index.html')
   })
 
   t.tearDown(fastify.close.bind(fastify))
@@ -674,11 +674,11 @@ t.test('sendFile', t => {
   fastify.register(fastifyStatic, pluginOptions)
 
   fastify.get('/foo/bar', function (req, reply) {
-    reply.sendFile('/index.html')
+    return reply.sendFile('/index.html')
   })
 
   fastify.get('/root/path/override/test', (request, reply) => {
-    reply.sendFile('/foo.html', path.join(__dirname, 'static', 'deep', 'path', 'for', 'test', 'purpose'))
+    return reply.sendFile('/foo.html', path.join(__dirname, 'static', 'deep', 'path', 'for', 'test', 'purpose'))
   })
 
   fastify.listen(0, err => {


### PR DESCRIPTION
Fastify v3 demands that a promise is returned from a route handler and the promise must not resolve to `undefined`. 

Returning `this` from the `sendFile` method means that the reply thenable can be returned from route handlers to avoid the error log in Fastify v3


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
