### PR TITLE
fix: prevent premature close error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ typings/
 .env
 
 package-lock.json
+
+.vscode

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "concat-stream": "^2.0.0",
     "coveralls": "^3.0.4",
     "eslint-plugin-typescript": "^0.14.0",
-    "fastify": "^3.0.0",
+    "fastify": "^3.7.0",
     "fastify-compress": "^3.3.1",
     "handlebars": "^4.7.6",
     "pre-commit": "^1.2.2",


### PR DESCRIPTION
As reported in https://github.com/fastify/fastify/issues/2616 & https://github.com/fastify/fastify-static/issues/116, the module fails and logs an error when client closes the request prematurely. This PR fixes that by adding a custom `errorHandler` in the  route config so that the specific `ERR_STREAM_PREMATURE_CLOSE` can be handled in a special way. For all other errors, we still fallback to the default `fastify.errorHandler` which was introduced in 3.7.0.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
