### PR TITLE
feat: implement download decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,31 @@ fastify.register(fastifyStatic, {
 
 ```
 
+### Sending a file with `content-disposition` header
+
+```js
+const fastify = require('fastify')()
+const path = require('path')
+
+fastify.register(require('fastify-static'), {
+  root: path.join(__dirname, 'public'),
+  prefix: '/public/', // optional: default '/'
+})
+
+fastify.get('/another/path', function (req, reply) {
+  return reply.download('myHtml.html', 'custom-filename.html') // sending path.join(__dirname, 'public', 'myHtml.html') directly with custom filename
+})
+
+fastify.get('/path/without/cache/control', function (req, reply) {
+  return reply.sendFile('myHtml.html', { cacheControl: false }) // serving a file disabling cache-control headers
+})
+
+fastify.get('/path/without/cache/control', function (req, reply) {
+  return reply.sendFile('myHtml.html', 'custom-filename.html', { cacheControl: false })
+})
+
+```
+
 ### Options
 
 #### `root` (required)
@@ -106,6 +131,8 @@ The following options are also supported and will be passed directly to the
 - [`index`](https://www.npmjs.com/package/send#index)
 - [`lastModified`](https://www.npmjs.com/package/send#lastmodified)
 - [`maxAge`](https://www.npmjs.com/package/send#maxage)
+
+You're able to alter this options when calling `reply.download('filename.html', options)` or `reply.download('filename.html', 'otherfilename.html', options)` on each response to a request.
 
 #### `redirect`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,9 @@ import { FastifyPlugin, FastifyReply, RawServerBase } from 'fastify'
 declare module "fastify" {
   interface FastifyReply {
     sendFile(filename: string, rootPath?: string): FastifyReply;
+    download(filepath: string, options?: SendOptions): FastifyReply;
+    download(filepath: string, filename?: string): FastifyReply;
+    download(filepath: string, filename?: string, options?: SendOptions): FastifyReply;
   }
 }
 
@@ -30,7 +33,20 @@ interface ListOptions {
   render: ListRender;
 }
 
-export interface FastifyStaticOptions {
+// Passed on to `send`
+interface SendOptions {
+  acceptRanges?: boolean;
+  cacheControl?: boolean;
+  dotfiles?: 'allow' | 'deny' | 'ignore';
+  etag?: boolean;
+  extensions?: string[];
+  immutable?: boolean;
+  index?: string[];
+  lastModified?: boolean;
+  maxAge?: string | number;
+}
+
+export interface FastifyStaticOptions extends SendOptions {
   root: string | string[];
   prefix?: string;
   prefixAvoidTrailingSlash?: boolean;
@@ -43,15 +59,15 @@ export interface FastifyStaticOptions {
   list?: boolean | ListOptions;
 
   // Passed on to `send`
-  acceptRanges?: boolean;
-  cacheControl?: boolean;
-  dotfiles?: 'allow' | 'deny' | 'ignore';
-  etag?: boolean;
-  extensions?: string[];
-  immutable?: boolean;
-  index?: string[];
-  lastModified?: boolean;
-  maxAge?: string | number;
+  // acceptRanges?: boolean;
+  // cacheControl?: boolean;
+  // dotfiles?: 'allow' | 'deny' | 'ignore';
+  // etag?: boolean;
+  // extensions?: string[];
+  // immutable?: boolean;
+  // index?: string[];
+  // lastModified?: boolean;
+  // maxAge?: string | number;
 }
 
 declare const fastifyStatic: FastifyPlugin<FastifyStaticOptions>

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,17 +57,6 @@ export interface FastifyStaticOptions extends SendOptions {
   redirect?: boolean;
   wildcard?: boolean | string;
   list?: boolean | ListOptions;
-
-  // Passed on to `send`
-  // acceptRanges?: boolean;
-  // cacheControl?: boolean;
-  // dotfiles?: 'allow' | 'deny' | 'ignore';
-  // etag?: boolean;
-  // extensions?: string[];
-  // immutable?: boolean;
-  // index?: string[];
-  // lastModified?: boolean;
-  // maxAge?: string | number;
 }
 
 declare const fastifyStatic: FastifyPlugin<FastifyStaticOptions>

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ async function fastifyStatic (fastify, opts) {
   }
 
   function pumpSendToReply (request, reply, pathname, rootPath, rootPathOffset = 0, pumpOptions = {}) {
-    const options = Object.assign(pumpOptions, sendOptions)
+    const options = Object.assign({}, sendOptions, pumpOptions)
 
     if (rootPath) {
       if (Array.isArray(rootPath)) {
@@ -160,14 +160,14 @@ async function fastifyStatic (fastify, opts) {
       return this
     })
 
-    fastify.decorateReply('download', function (filePath, fileName, options) {
-      options = typeof fileName === 'object' ? fileName : (options || {})
+    fastify.decorateReply('download', function (filePath, fileName, options = {}) {
+      const { root, ...opts } = typeof fileName === 'object' ? fileName : options
       fileName = typeof fileName === 'string' ? fileName : filePath
 
       // Set content disposition header
       this.header('content-disposition', contentDisposition(fileName))
 
-      pumpSendToReply(this.request, this, filePath, options.root, 0, options)
+      pumpSendToReply(this.request, this, filePath, root, 0, opts)
 
       return this
     })

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const statSync = require('fs').statSync
 const { PassThrough } = require('readable-stream')
 const glob = require('glob')
 const send = require('send')
+const contentDisposition = require('content-disposition')
 const fp = require('fastify-plugin')
 const util = require('util')
 const globPromise = util.promisify(glob)
@@ -39,8 +40,8 @@ async function fastifyStatic (fastify, opts) {
     maxAge: opts.maxAge
   }
 
-  function pumpSendToReply (request, reply, pathname, rootPath, rootPathOffset = 0) {
-    const options = Object.assign({}, sendOptions)
+  function pumpSendToReply (request, reply, pathname, rootPath, rootPathOffset = 0, pumpOptions = {}) {
+    const options = Object.assign(pumpOptions, sendOptions)
 
     if (rootPath) {
       if (Array.isArray(rootPath)) {
@@ -156,6 +157,18 @@ async function fastifyStatic (fastify, opts) {
   if (opts.decorateReply !== false) {
     fastify.decorateReply('sendFile', function (filePath, rootPath) {
       pumpSendToReply(this.request, this, filePath, rootPath)
+      return this
+    })
+
+    fastify.decorateReply('download', function (filePath, fileName, options) {
+      options = typeof fileName === 'object' ? fileName : (options || {})
+      fileName = typeof fileName === 'string' ? fileName : filePath
+
+      // Set content disposition header
+      this.header('content-disposition', contentDisposition(fileName))
+
+      pumpSendToReply(this.request, this, filePath, options.root, 0, options)
+
       return this
     })
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-static",
   "dependencies": {
+    "content-disposition": "^0.5.3",
     "fastify-plugin": "^3.0.0",
     "glob": "^7.1.4",
     "readable-stream": "^3.4.0",

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -951,6 +951,46 @@ t.test('sendFile disabled', t => {
   })
 })
 
+t.test('download disabled', t => {
+  t.plan(3)
+
+  const pluginOptions = {
+    root: path.join(__dirname, '/static'),
+    prefix: '/static',
+    decorateReply: false
+  }
+  const fastify = Fastify()
+  fastify.register(fastifyStatic, pluginOptions)
+
+  fastify.get('/foo/bar', function (req, reply) {
+    if (typeof reply.download === 'undefined') {
+      t.equals(reply.download, undefined)
+      reply.send('pass')
+    } else {
+      reply.send('fail')
+    }
+  })
+
+  fastify.listen(0, err => {
+    t.error(err)
+
+    fastify.server.unref()
+
+    t.test('reply.sendFile undefined', t => {
+      t.plan(3)
+      simple.concat({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port + '/foo/bar',
+        followRedirect: false
+      }, (err, response, body) => {
+        t.error(err)
+        t.strictEqual(response.statusCode, 200)
+        t.strictEqual(body.toString(), 'pass')
+      })
+    })
+  })
+})
+
 t.test('prefix default', t => {
   t.plan(1)
   const pluginOptions = { root: path.join(__dirname, 'static') }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -41,6 +41,18 @@ appWithHttp2
     appWithHttp2.get('/', (request, reply) => {
       reply.sendFile('some-file-name')
     })
+
+    appWithHttp2.get('/download', (request, reply) => {
+      reply.download('some-file-name')
+    })
+
+    appWithHttp2.get('/download/1', (request, reply) => {
+      reply.download('some-file-name', { maxAge: '2 days' })
+    })
+
+    appWithHttp2.get('/download/2', (request, reply) => {
+      reply.download('some-file-name', 'some-filename' ,{ cacheControl: false, acceptRanges: true })
+    })
   })
 
 const multiRootAppWithImplicitHttp = fastify()
@@ -51,6 +63,18 @@ multiRootAppWithImplicitHttp
   .after(() => {
     multiRootAppWithImplicitHttp.get('/', (request, reply) => {
       reply.sendFile('some-file-name')
+    })
+
+    multiRootAppWithImplicitHttp.get('/download', (request, reply) => {
+      reply.download('some-file-name')
+    })
+
+    multiRootAppWithImplicitHttp.get('/download/1', (request, reply) => {
+      reply.download('some-file-name', { maxAge: '2 days' })
+    })
+
+    multiRootAppWithImplicitHttp.get('/download/2', (request, reply) => {
+      reply.download('some-file-name', 'some-filename', { cacheControl: false, acceptRanges: true })
     })
   })
   


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

The PR implements similar feature as `res.download` on [Express.js](https://expressjs.com/es/4x/api.html#res.download) on fastify, decorating `reply` object with a `download` function.

Closes [#1563](https://github.com/fastify/fastify/issues/1563)

**Pending**

- [x] Types
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
