### PR TITLE
fix content-type header for precompressed assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,7 @@ async function fastifyStatic (fastify, opts) {
     } else {
       wrap.on('pipe', function () {
         if (encodingExt) {
+          reply.header('content-type', getContentType(pathname))
           reply.header('content-encoding', encodingExt)
         }
         reply.send(wrap)
@@ -375,6 +376,18 @@ function checkPath (fastify, rootPath) {
 }
 
 const supportedEncodings = ['br', 'gzip', 'deflate']
+
+function getContentType (path) {
+  const type = send.mime.lookup(path)
+  if (!type) {
+    return
+  }
+  const charset = send.mime.charsets.lookup(type)
+  if (!charset) {
+    return type
+  }
+  return `${type}; charset=${charset}`
+}
 
 // Adapted from https://github.com/fastify/fastify-compress/blob/fa5c12a5394285c86d9f438cb39ff44f3d5cde79/index.js#L442
 function checkEncodingHeaders (headers, checked) {

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -2911,6 +2911,7 @@ t.test(
       }
     })
 
+    genericResponseChecks(t, response)
     t.equal(response.headers['content-encoding'], 'br')
     t.equal(response.statusCode, 200)
     t.same(response.rawPayload, allThreeBr)
@@ -2940,6 +2941,7 @@ t.test(
       }
     })
 
+    genericResponseChecks(t, response)
     t.equal(response.headers['content-encoding'], 'gz')
     t.equal(response.statusCode, 200)
     t.same(response.rawPayload, gzipOnly)
@@ -2969,6 +2971,7 @@ t.test(
       }
     })
 
+    genericResponseChecks(t, response)
     t.equal(response.headers['content-encoding'], undefined)
     t.equal(response.statusCode, 200)
     t.equal(response.body, uncompressedStatic)
@@ -2999,6 +3002,7 @@ t.test(
       }
     })
 
+    genericResponseChecks(t, response)
     t.equal(response.headers['content-encoding'], 'br')
     t.equal(response.statusCode, 200)
     t.same(response.rawPayload, allThreeBr)
@@ -3029,6 +3033,7 @@ t.test(
       }
     })
 
+    genericResponseChecks(t, response)
     t.equal(response.headers['content-encoding'], 'gz')
     t.equal(response.statusCode, 200)
     t.same(response.rawPayload, gzipOnly)
@@ -3059,6 +3064,7 @@ t.test(
       }
     })
 
+    genericResponseChecks(t, response)
     t.equal(response.headers['content-encoding'], undefined)
     t.equal(response.statusCode, 200)
     t.equal(response.body, uncompressedStatic)
@@ -3085,6 +3091,7 @@ t.test(
       url: '/static-pre-compressed/uncompressed.html'
     })
 
+    genericResponseChecks(t, response)
     t.equal(response.headers['content-encoding'], undefined)
     t.equal(response.statusCode, 200)
     t.equal(response.body, uncompressedStatic)


### PR DESCRIPTION
Related to #158

When serving a precompressed file, we should derive the `content-type` header from the original extension rather than `.gz` or `.br`.

This PR more or less replicates [what send does internally](https://github.com/pillarjs/send/blob/de073ed3237ade9ff71c61673a34474b30e5d45b/index.js#L833).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
