### PR TITLE
Call 404 handler if requested path is a dotfile

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,12 @@ async function fastifyStatic (fastify, opts) {
         return reply.callNotFound()
       }
 
-      // err is an object created by `http-errors`
+      // The `send` library terminates the request with a 404 if the requested
+      // path contains a dotfile and `send` is initialized with `{dotfiles:
+      // 'ignore'}`. `send` aborts the request before getting far enough to
+      // check if the file exists (hence, a 404 `NotFoundError` instead of
+      // `ENOENT`).
+      // https://github.com/pillarjs/send/blob/de073ed3237ade9ff71c61673a34474b30e5d45b/index.js#L582
       if (err.status === 404) {
         return reply.callNotFound()
       }

--- a/index.js
+++ b/index.js
@@ -187,6 +187,12 @@ async function fastifyStatic (fastify, opts) {
 
         return reply.callNotFound()
       }
+
+      // err is an object created by `http-errors`
+      if (err.status === 404) {
+        return reply.callNotFound()
+      }
+
       reply.send(err)
     })
 


### PR DESCRIPTION
This closes #218 and #219. The registered `notFoundHandler` wasn't being called when the request path included dotfiles with `send`'s default configuration of ignoring dotfiles. Previous behavior resulted in `fastify` printing an exception and leaving the request hanging.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
