### PR TITLE
fix(docs): list example and index option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ This function allows filtering the served files.
 If the function returns `true`, the file will be served.
 If the function returns `false`, Fastify's 404 handler will be called.
 
+#### `index`
+
+Default: `undefined`
+
+Under the hood we use [send](https://github.com/pillarjs/send#index) lib that by default supports "index.html" files. 
+To disable this set false or to supply a new index pass a string or an array in preferred order.
+
 #### `list`
 
 Default: `undefined`
@@ -187,6 +194,7 @@ Default response is json.
 fastify.register(require('fastify-static'), {
   root: path.join(__dirname, 'public'),
   prefix: '/public/',
+  index: false
   list: true
 })
 ```


### PR DESCRIPTION
Witout `index=false` option `fastify-static` will return 404 as it will look for `index.hml` instead returning list of files.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
