### PR TITLE
Extended dir-list information

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,14 @@ Options: `html`, `json`
 
 Directory list can be also in `html` format; in that case, `list.render` function is required.
 
+You can override the option with URL parameter `format`. Options are `html` and `json`.
+
+```bash
+GET .../public/assets?format=json
+```
+
+will return the response as json independent of `list.format`.
+
 **Example:**
 
 ```js
@@ -295,6 +303,79 @@ GET .../public
 GET .../public/
 GET .../public/index
 GET .../public/index.json
+```
+
+#### `list.extendedFolderInfo`
+
+Default: `undefined`
+
+If `true` some extended information for folders will be accessible in `list.render` and in the json response.
+
+```js
+render(dirs, files) {
+  const dir = dirs[0];
+  dir.fileCount // number of files in this folder
+  dir.totalFileCount // number of files in this folder (recursive)
+  dir.folderCount // number of folders in this folder
+  dir.totalFolderCount // number of folders in this folder (recursive)
+  dir.totalSize // size of all files in this folder (recursive)
+  dir.lastModified // most recent last modified timestamp of all files in this folder (recursive)
+}
+```
+
+Warning: This will slightly decrease the performance, especially for deeply nested file structures.
+
+#### `list.jsonFormat`
+
+Default: `names`
+
+Options: `names`, `extended`
+
+This option determines the output format when `json` is selected.
+
+`names`:
+```json
+{
+  "dirs": [
+    "dir1",
+    "dir2"
+  ],
+  "files": [
+    "file1.txt",
+    "file2.txt"
+  ]
+}
+```
+
+`extended`:
+```json
+{
+  "dirs": [
+    {
+      "name": "dir1",
+      "stats": {
+        "dev": 2100,
+        "size": 4096,
+        ...
+      },
+      "extendedInfo": {
+        "fileCount": 4,
+        "totalSize": 51233,
+        ...
+      }
+    }
+  ],
+  "files": [
+    {
+      "name": "file1.txt",
+      "stats": {
+        "dev": 2200,
+        "size": 554,
+        ...
+      }
+    }
+  ]
+}
 ```
 
 #### `preCompressed`

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@
 /// <reference types="node" />
 
 import { FastifyPluginCallback, FastifyReply } from 'fastify';
+import { Stats } from 'fs';
 
 declare module "fastify" {
   interface FastifyReply {
@@ -13,14 +14,25 @@ declare module "fastify" {
   }
 }
 
+interface ExtendedInformation {
+  fileCount: number;
+  totalFileCount: number;
+  folderCount: number;
+  totalFolderCount: number;
+  totalSize: number;
+}
+
 interface ListDir {
   href: string;
   name: string;
+  stats: Stats;
+  extendedInfo?: ExtendedInformation;
 }
 
 interface ListFile {
   href: string;
   name: string;
+  stats: Stats;
 }
 
 interface ListRender {
@@ -31,6 +43,8 @@ interface ListOptions {
   format: 'json' | 'html';
   names: string[];
   render: ListRender;
+  extendedFolderInfo?: boolean;
+  jsonFormat?: 'names' | 'extended';
 }
 
 // Passed on to `send`

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ interface ExtendedInformation {
   folderCount: number;
   totalFolderCount: number;
   totalSize: number;
+  lastModified: number;
 }
 
 interface ListDir {

--- a/index.js
+++ b/index.js
@@ -144,6 +144,7 @@ async function fastifyStatic (fastify, opts) {
     stream.on('directory', function (_, path) {
       if (opts.list) {
         return dirList.send({
+          request,
           reply,
           dir: path,
           options: opts.list,
@@ -164,7 +165,7 @@ async function fastifyStatic (fastify, opts) {
       if (err.code === 'ENOENT') {
         // if file exists, send real file, otherwise send dir list if name match
         if (opts.list && dirList.handle(pathname, opts.list)) {
-          return dirList.send({ reply, dir: dirList.path(opts.root, pathname), options: opts.list, route: pathname })
+          return dirList.send({ request, reply, dir: dirList.path(opts.root, pathname), options: opts.list, route: pathname })
         }
 
         // root paths left to try?

--- a/lib/dirList.js
+++ b/lib/dirList.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const path = require('path')
-const fs = require('fs')
+const fs = require('fs/promises')
 
 const dirList = {
   /**
@@ -10,36 +10,81 @@ const dirList = {
    * @param {function(error, entries)} callback
    * note: can't use glob because don't get error on non existing dir
    */
-  list: function (dir, callback) {
+  list: async function (dir, options) {
     const entries = { dirs: [], files: [] }
-    fs.readdir(dir, (err, files) => {
-      if (err) {
-        return callback(err)
-      }
-      if (files.length < 1) {
-        callback(null, entries)
+    const files = await fs.readdir(dir)
+    if (files.length < 1) {
+      return entries
+    }
+
+    await Promise.all(files.map(async filename => {
+      let stats
+      try {
+        stats = await fs.stat(path.join(dir, filename))
+      } catch (error) {
         return
       }
-      let j = 0
-      for (let i = 0; i < files.length; i++) {
-        const filename = files[i]
-        fs.stat(path.join(dir, filename), (err, file) => {
-          if (!err) {
-            if (file.isDirectory()) {
-              entries.dirs.push(filename)
-            } else {
-              entries.files.push(filename)
-            }
-          }
-
-          if (j++ >= files.length - 1) {
-            entries.dirs.sort()
-            entries.files.sort()
-            callback(null, entries)
-          }
-        })
+      const entry = { name: filename, stats }
+      if (stats.isDirectory()) {
+        if (options.extendedFolderInfo) {
+          entry.extendedInfo = await getExtendedInfo(path.join(dir, filename))
+        }
+        entries.dirs.push(entry)
+      } else {
+        entries.files.push(entry)
       }
-    })
+    }))
+
+    async function getExtendedInfo (folderPath) {
+      const depth = folderPath.split(path.sep).length
+      let totalSize = 0
+      let fileCount = 0
+      let totalFileCount = 0
+      let folderCount = 0
+      let totalFolderCount = 0
+
+      async function walk (dir) {
+        const files = await fs.readdir(dir)
+        await Promise.all(files
+          .map(async filename => {
+            const filePath = path.join(dir, filename)
+            let stats
+            try {
+              stats = await fs.stat(filePath)
+            } catch (error) {
+              return
+            }
+
+            if (stats.isDirectory()) {
+              totalFolderCount++
+              if (filePath.split(path.sep).length === depth + 1) {
+                folderCount++
+              }
+              await walk(filePath)
+            } else {
+              totalSize += stats.size
+              totalFileCount++
+              if (filePath.split(path.sep).length === depth + 1) {
+                fileCount++
+              }
+            }
+          })
+        )
+      }
+
+      await walk(folderPath)
+      return {
+        totalSize,
+        fileCount,
+        totalFileCount,
+        folderCount,
+        totalFolderCount
+      }
+    }
+
+    entries.dirs.sort((a, b) => a.name.localeCompare(b.name))
+    entries.files.sort((a, b) => a.name.localeCompare(b.name))
+    return entries
   },
 
   /**
@@ -49,33 +94,40 @@ const dirList = {
    * @param {ListOptions} options
    * @param {string} route request route
    */
-  send: function ({ reply, dir, options, route }) {
-    dirList.list(dir, (err, entries) => {
-      if (err) {
-        reply.callNotFound()
-        return
-      }
+  send: async function ({ reply, dir, options, route }) {
+    let entries
+    try {
+      entries = await dirList.list(dir, options)
+    } catch (error) {
+      return reply.callNotFound()
+    }
+    if (options.format !== 'html') {
+      if (options.jsonFormat !== 'extended') {
+        const nameEntries = { dirs: [], files: [] }
+        entries.dirs.forEach(entry => nameEntries.dirs.push(entry.name))
+        entries.files.forEach(entry => nameEntries.files.push(entry.name))
 
-      if (options.format !== 'html') {
+        reply.send(nameEntries)
+      } else {
         reply.send(entries)
-        return
       }
+      return
+    }
 
-      const html = options.render(
-        entries.dirs.map(entry => dirList.htmlInfo(entry, route)),
-        entries.files.map(entry => dirList.htmlInfo(entry, route)))
-      reply.type('text/html').send(html)
-    })
+    const html = options.render(
+      entries.dirs.map(entry => dirList.htmlInfo(entry, route)),
+      entries.files.map(entry => dirList.htmlInfo(entry, route)))
+    reply.type('text/html').send(html)
   },
 
   /**
    * provide the html information about entry and route, to get name and full route
-   * @param {string} entry file or dir name
+   * @param entry file or dir name and stats
    * @param {string} route request route
    * @return {ListFile}
    */
   htmlInfo: function (entry, route) {
-    return { href: path.join(path.dirname(route), entry).replace(/\\/g, '/'), name: entry }
+    return { href: path.join(path.dirname(route), entry.name).replace(/\\/g, '/'), name: entry.name, stats: entry.stats, extendedInfo: entry.extendedInfo }
   },
 
   /**

--- a/lib/dirList.js
+++ b/lib/dirList.js
@@ -97,14 +97,15 @@ const dirList = {
    * @param {ListOptions} options
    * @param {string} route request route
    */
-  send: async function ({ reply, dir, options, route }) {
+  send: async function ({ request, reply, dir, options, route }) {
     let entries
     try {
       entries = await dirList.list(dir, options)
     } catch (error) {
       return reply.callNotFound()
     }
-    if (options.format !== 'html') {
+    const format = request.query.format || options.format
+    if (format !== 'html') {
       if (options.jsonFormat !== 'extended') {
         const nameEntries = { dirs: [], files: [] }
         entries.dirs.forEach(entry => nameEntries.dirs.push(entry.name))

--- a/lib/dirList.js
+++ b/lib/dirList.js
@@ -42,6 +42,7 @@ const dirList = {
       let totalFileCount = 0
       let folderCount = 0
       let totalFolderCount = 0
+      let lastModified = 0
 
       async function walk (dir) {
         const files = await fs.readdir(dir)
@@ -67,6 +68,7 @@ const dirList = {
               if (filePath.split(path.sep).length === depth + 1) {
                 fileCount++
               }
+              lastModified = Math.max(lastModified, parseInt(stats.mtimeMs))
             }
           })
         )
@@ -78,7 +80,8 @@ const dirList = {
         fileCount,
         totalFileCount,
         folderCount,
-        totalFolderCount
+        totalFolderCount,
+        lastModified
       }
     }
 

--- a/test/dir-list.test.js
+++ b/test/dir-list.test.js
@@ -387,6 +387,55 @@ t.test('dir list json format - extended info', t => {
   })
 })
 
+t.test('dir list - url parameter format', t => {
+  t.plan(13)
+
+  const options = {
+    root: path.join(__dirname, '/static'),
+    prefix: '/public',
+    index: false,
+    list: {
+      format: 'html',
+      render (dirs, files) {
+        return 'html'
+      }
+    }
+  }
+  const route = '/public/'
+
+  helper.arrange(t, options, (url) => {
+    simple.concat({
+      method: 'GET',
+      url: url + route
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(body.toString(), 'html')
+      t.ok(response.headers['content-type'].includes('text/html'))
+    })
+
+    simple.concat({
+      method: 'GET',
+      url: url + route + '?format=html'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(body.toString(), 'html')
+      t.ok(response.headers['content-type'].includes('text/html'))
+    })
+
+    simple.concat({
+      method: 'GET',
+      url: url + route + '?format=json'
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.ok(body.toString())
+      t.ok(response.headers['content-type'].includes('application/json'))
+    })
+  })
+})
+
 t.test('dir list on empty dir', t => {
   t.plan(2)
 

--- a/test/dir-list.test.js
+++ b/test/dir-list.test.js
@@ -288,13 +288,20 @@ t.test('dir list html format - extended info', t => {
       format: 'html',
       extendedFolderInfo: true,
       render (dirs, files) {
-        t.ok(dirs.every(every))
+        t.test('dirs', t => {
+          t.plan(dirs.length * 7)
 
-        function every (value) {
-          const attrs = ['fileCount', 'totalFileCount', 'folderCount', 'totalFolderCount', 'totalSize']
-          return value.extendedInfo &&
-            attrs.every(attr => typeof value.extendedInfo[attr] === 'number')
-        }
+          for (const value of dirs) {
+            t.ok(value.extendedInfo)
+
+            t.equal(typeof value.extendedInfo.fileCount, 'number')
+            t.equal(typeof value.extendedInfo.totalFileCount, 'number')
+            t.equal(typeof value.extendedInfo.folderCount, 'number')
+            t.equal(typeof value.extendedInfo.totalFolderCount, 'number')
+            t.equal(typeof value.extendedInfo.totalSize, 'number')
+            t.equal(typeof value.extendedInfo.lastModified, 'number')
+          }
+        })
       }
     }
   }


### PR DESCRIPTION
I added some features to the dirlist.
Additionally to the names I added the stats of the dirs/files and some extended information for the dirs.
You can change the format (html/json) via the URL-Parameter.

Furthermore I replaced the callbacks with promises.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
