### PR TITLE
fix: serve directory without trailing slash fixes(#272)

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,6 +172,19 @@ async function fastifyStatic (fastify, opts) {
           reply.send(error)
         }
       } else {
+        // if is a directory path without a trailing slash, and has an index file, reply as if it has a trailing slash
+        if (!pathname.endsWith('/') && findIndexFile(pathname, options.root, options.index)) {
+          return pumpSendToReply(
+            request,
+            reply,
+            pathname + '/',
+            rootPath,
+            undefined,
+            undefined,
+            checkedEncodings
+          )
+        }
+
         reply.callNotFound()
       }
     })

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -2537,7 +2537,7 @@ t.test('register /static with redirect true and wildcard false', t => {
   })
 })
 
-t.test('trailing slash behavior with redirect = false', (t) => {
+t.only('trailing slash behavior with redirect = false', (t) => {
   t.plan(6)
 
   const fastify = Fastify()
@@ -2588,14 +2588,14 @@ t.test('trailing slash behavior with redirect = false', (t) => {
       })
     })
 
-    t.test('deep path with index.html but no trailing slash => 404', (t) => {
+    t.only('deep path with index.html but no trailing slash => 200', (t) => {
       t.plan(2)
       simple.concat({
         method: 'GET',
         url: host + '/static/deep/path/for/test'
       }, (err, response) => {
         t.error(err)
-        t.equal(response.statusCode, 404)
+        t.equal(response.statusCode, 200)
       })
     })
 

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -2537,7 +2537,7 @@ t.test('register /static with redirect true and wildcard false', t => {
   })
 })
 
-t.only('trailing slash behavior with redirect = false', (t) => {
+t.test('trailing slash behavior with redirect = false', (t) => {
   t.plan(6)
 
   const fastify = Fastify()
@@ -2588,7 +2588,7 @@ t.only('trailing slash behavior with redirect = false', (t) => {
       })
     })
 
-    t.only('deep path with index.html but no trailing slash => 200', (t) => {
+    t.test('deep path with index.html but no trailing slash => 200', (t) => {
       t.plan(2)
       simple.concat({
         method: 'GET',


### PR DESCRIPTION
fixes #272 in conjunction  with https://github.com/fastify/fastify-static/pull/271