### PR TITLE
fix: update glob to version 8 and fix broken tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,7 +332,7 @@ async function fastifyStatic (fastify, opts) {
       const routes = new Set()
 
       for (const rootPath of Array.isArray(sendOptions.root) ? sendOptions.root : [sendOptions.root]) {
-        const files = await globPromise(path.join(rootPath, globPattern), { nodir: true })
+        const files = await globPromise(path.join(rootPath, globPattern).replaceAll(path.win32.sep, path.posix.sep), { nodir: true })
         const indexes = typeof opts.index === 'undefined' ? ['index.html'] : [].concat(opts.index)
 
         for (let file of files) {

--- a/index.js
+++ b/index.js
@@ -331,8 +331,10 @@ async function fastifyStatic (fastify, opts) {
       const indexDirs = new Map()
       const routes = new Set()
 
+      const winSeparatorRegex = new RegExp(`\\${path.win32.sep}`, 'g')
+
       for (const rootPath of Array.isArray(sendOptions.root) ? sendOptions.root : [sendOptions.root]) {
-        const files = await globPromise(path.join(rootPath, globPattern).replaceAll(path.win32.sep, path.posix.sep), { nodir: true })
+        const files = await globPromise(path.join(rootPath, globPattern).replace(winSeparatorRegex, path.posix.sep), { nodir: true })
         const indexes = typeof opts.index === 'undefined' ? ['index.html'] : [].concat(opts.index)
 
         for (let file of files) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "content-disposition": "^0.5.3",
     "encoding-negotiator": "^2.0.1",
     "fastify-plugin": "^3.0.0",
-    "glob": "^7.1.4",
+    "glob": "^8.0.1",
     "p-limit": "^3.1.0",
     "readable-stream": "^3.4.0",
     "send": "^0.18.0"


### PR DESCRIPTION
In this release glob stopped accepting backward slashes on it's patterns, since `path.join` will return backward slashes on windows they have to be replaced by a forward slash which is the posix separator.

I'm not entirely sure about all the implications of this change, specially regarding performance but all the tests seem to be passing and everything should work normally AFAIK since windows accept both backward and forward slashes as path separator.

Closes #281 since glob is already being updated here.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
