### PR TITLE
fix: windows path resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,8 +330,10 @@ async function fastifyStatic (fastify, opts) {
       const indexDirs = new Map()
       const routes = new Set()
 
+      const winSeparatorRegex = new RegExp(`\\${path.win32.sep}`, 'g')
+
       for (const rootPath of Array.isArray(sendOptions.root) ? sendOptions.root : [sendOptions.root]) {
-        const files = await globPromise(path.join(rootPath, globPattern), { nodir: true })
+        const files = await globPromise(path.join(rootPath, globPattern).replace(winSeparatorRegex, path.posix.sep), { nodir: true })
         const indexes = typeof opts.index === 'undefined' ? ['index.html'] : [].concat(opts.index)
 
         for (let file of files) {


### PR DESCRIPTION
Apply windows path resolution [PR](https://github.com/fastify/fastify-static/pull/297) for fastify-static v5

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
