### PR TITLE
make type definitons `"module": "nodenext"` compatible

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,6 +108,6 @@ declare namespace fastifyStatic {
   export { fastifyStatic as default };
 }
 
-declare function fastifyStatic(): FastifyPluginCallback<fastifyStatic.FastifyStaticOptions>;
+declare function fastifyStatic(...params: Parameters<FastifyPluginCallback<NonNullable<fastifyStatic.FastifyStaticOptions>>>): void
 
 export = fastifyStatic;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,100 +8,106 @@ import { Stats } from 'fs';
 declare module "fastify" {
   interface FastifyReply {
     sendFile(filename: string, rootPath?: string): FastifyReply;
-    sendFile(filename: string, options?: SendOptions): FastifyReply;
-    sendFile(filename: string, rootPath?: string, options?: SendOptions): FastifyReply;
-    download(filepath: string, options?: SendOptions): FastifyReply;
+    sendFile(filename: string, options?: fastifyStatic.SendOptions): FastifyReply;
+    sendFile(filename: string, rootPath?: string, options?: fastifyStatic.SendOptions): FastifyReply;
+    download(filepath: string, options?: fastifyStatic.SendOptions): FastifyReply;
     download(filepath: string, filename?: string): FastifyReply;
-    download(filepath: string, filename?: string, options?: SendOptions): FastifyReply;
+    download(filepath: string, filename?: string, options?: fastifyStatic.SendOptions): FastifyReply;
   }
 }
 
-interface ExtendedInformation {
-  fileCount: number;
-  totalFileCount: number;
-  folderCount: number;
-  totalFolderCount: number;
-  totalSize: number;
-  lastModified: number;
-}
+declare namespace fastifyStatic {
+  export interface ExtendedInformation {
+    fileCount: number;
+    totalFileCount: number;
+    folderCount: number;
+    totalFolderCount: number;
+    totalSize: number;
+    lastModified: number;
+  }
 
-interface ListDir {
-  href: string;
-  name: string;
-  stats: Stats;
-  extendedInfo?: ExtendedInformation;
-}
+  export interface ListDir {
+    href: string;
+    name: string;
+    stats: Stats;
+    extendedInfo?: ExtendedInformation;
+  }
 
-interface ListFile {
-  href: string;
-  name: string;
-  stats: Stats;
-}
+  export interface ListFile {
+    href: string;
+    name: string;
+    stats: Stats;
+  }
 
-interface ListRender {
-  (dirs: ListDir[], files: ListFile[]): string;
-}
+  export interface ListRender {
+    (dirs: ListDir[], files: ListFile[]): string;
+  }
 
-interface ListOptions {
-  names?: string[];
-  extendedFolderInfo?: boolean;
-  jsonFormat?: 'names' | 'extended';
-}
+  export interface ListOptions {
+    names?: string[];
+    extendedFolderInfo?: boolean;
+    jsonFormat?: 'names' | 'extended';
+  }
 
-interface ListOptionsJsonFormat extends ListOptions {
-  format: 'json';
-  // Required when the URL parameter `format=html` exists
-  render?: ListRender;
-}
+  export interface ListOptionsJsonFormat extends ListOptions {
+    format: 'json';
+    // Required when the URL parameter `format=html` exists
+    render?: ListRender;
+  }
 
-interface ListOptionsHtmlFormat extends ListOptions {
-  format: 'html';
-  render: ListRender;
-}
-
-// Passed on to `send`
-interface SendOptions {
-  acceptRanges?: boolean;
-  cacheControl?: boolean;
-  dotfiles?: 'allow' | 'deny' | 'ignore';
-  etag?: boolean;
-  extensions?: string[];
-  immutable?: boolean;
-  index?: string[] | string | false;
-  lastModified?: boolean;
-  maxAge?: string | number;
-}
-
-export interface FastifyStaticOptions extends SendOptions {
-  root: string | string[];
-  prefix?: string;
-  prefixAvoidTrailingSlash?: boolean;
-  serve?: boolean;
-  decorateReply?: boolean;
-  schemaHide?: boolean;
-  setHeaders?: (...args: any[]) => void;
-  redirect?: boolean;
-  wildcard?: boolean;
-  list?: boolean | ListOptionsJsonFormat | ListOptionsHtmlFormat;
-  allowedPath?: (pathName: string, root?: string) => boolean;
-  /**
-   * @description
-   * Opt-in to looking for pre-compressed files
-   */
-  preCompressed?: boolean;
+  export interface ListOptionsHtmlFormat extends ListOptions {
+    format: 'html';
+    render: ListRender;
+  }
 
   // Passed on to `send`
-  acceptRanges?: boolean;
-  cacheControl?: boolean;
-  dotfiles?: 'allow' | 'deny' | 'ignore';
-  etag?: boolean;
-  extensions?: string[];
-  immutable?: boolean;
-  index?: string[] | string | false;
-  lastModified?: boolean;
-  maxAge?: string | number;
+  export interface SendOptions {
+    acceptRanges?: boolean;
+    cacheControl?: boolean;
+    dotfiles?: 'allow' | 'deny' | 'ignore';
+    etag?: boolean;
+    extensions?: string[];
+    immutable?: boolean;
+    index?: string[] | string | false;
+    lastModified?: boolean;
+    maxAge?: string | number;
+  }
+
+  export interface FastifyStaticOptions extends SendOptions {
+    root: string | string[];
+    prefix?: string;
+    prefixAvoidTrailingSlash?: boolean;
+    serve?: boolean;
+    decorateReply?: boolean;
+    schemaHide?: boolean;
+    setHeaders?: (...args: any[]) => void;
+    redirect?: boolean;
+    wildcard?: boolean;
+    list?: boolean | ListOptionsJsonFormat | ListOptionsHtmlFormat;
+    allowedPath?: (pathName: string, root?: string) => boolean;
+    /**
+     * @description
+     * Opt-in to looking for pre-compressed files
+     */
+    preCompressed?: boolean;
+
+    // Passed on to `send`
+    acceptRanges?: boolean;
+    cacheControl?: boolean;
+    dotfiles?: 'allow' | 'deny' | 'ignore';
+    etag?: boolean;
+    extensions?: string[];
+    immutable?: boolean;
+    index?: string[] | string | false;
+    lastModified?: boolean;
+    maxAge?: string | number;
+  }
+
+  export const fastifyStatic: FastifyPluginCallback<FastifyStaticOptions>;
+
+  export { fastifyStatic as default };
 }
 
-export declare const fastifyStatic: FastifyPluginCallback<FastifyStaticOptions>
+declare function fastifyStatic(): FastifyPluginCallback<fastifyStatic.FastifyStaticOptions>;
 
-export default fastifyStatic;
+export = fastifyStatic;

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,8 @@ declare module "fastify" {
   }
 }
 
+type FastifyStaticPlugin = FastifyPluginCallback<NonNullable<fastifyStatic.FastifyStaticOptions>>;
+
 declare namespace fastifyStatic {
   export interface ExtendedInformation {
     fileCount: number;
@@ -103,11 +105,11 @@ declare namespace fastifyStatic {
     maxAge?: string | number;
   }
 
-  export const fastifyStatic: FastifyPluginCallback<FastifyStaticOptions>;
+  export const fastifyStatic: FastifyStaticPlugin;
 
   export { fastifyStatic as default };
 }
 
-declare function fastifyStatic(...params: Parameters<FastifyPluginCallback<NonNullable<fastifyStatic.FastifyStaticOptions>>>): void
+declare function fastifyStatic(...params: Parameters<FastifyStaticPlugin>): ReturnType<FastifyStaticPlugin>;
 
 export = fastifyStatic;

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,6 +1,34 @@
-import fastify from 'fastify'
-import { expectAssignable, expectError } from 'tsd'
-import fastifyStatic, { FastifyStaticOptions } from '../..'
+import fastify, { FastifyInstance, FastifyPluginCallback } from 'fastify'
+import { Server } from 'http';
+import { expectAssignable, expectError, expectType } from 'tsd'
+import * as fastifyStaticStar from '../..';
+import fastifyStatic, {
+  FastifyStaticOptions, 
+  fastifyStatic as fastifyStaticNamed,
+} from '../..'
+
+import fastifyStaticCjsImport = require('../..');
+const fastifyStaticCjs = require('../..');
+
+const app: FastifyInstance = fastify();
+
+app.register(fastifyStatic);
+app.register(fastifyStaticNamed);
+app.register(fastifyStaticCjs);
+app.register(fastifyStaticCjsImport.default);
+app.register(fastifyStaticCjsImport.fastifyStatic);
+app.register(fastifyStaticStar.default);
+app.register(fastifyStaticStar.fastifyStatic);
+
+expectType<FastifyPluginCallback<FastifyStaticOptions, Server>>(fastifyStatic);
+expectType<FastifyPluginCallback<FastifyStaticOptions, Server>>(fastifyStaticNamed);
+expectType<FastifyPluginCallback<FastifyStaticOptions, Server>>(fastifyStaticCjsImport.default);
+expectType<FastifyPluginCallback<FastifyStaticOptions, Server>>(fastifyStaticCjsImport.fastifyStatic);
+expectType<FastifyPluginCallback<FastifyStaticOptions, Server>>(fastifyStaticStar.default);
+expectType<FastifyPluginCallback<FastifyStaticOptions, Server>>(
+fastifyStaticStar.fastifyStatic
+);
+expectType<any>(fastifyStaticCjs);
 
 const appWithImplicitHttp = fastify()
 const options: FastifyStaticOptions = {


### PR DESCRIPTION
* see https://github.com/microsoft/TypeScript/issues/48845

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
