### PR TITLE
chore: remove `return` from sync route handlers examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ fastify.get('/another/path', function (req, reply) {
 })
 
 fastify.get('another/patch-async', async function (req, reply) {
+  // an async handler must always return the reply object
   return reply.download('myHtml.html', 'custom-filename.html')
 })
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,19 @@ fastify.register(require('@fastify/static'), {
 })
 
 fastify.get('/another/path', function (req, reply) {
-  return reply.sendFile('myHtml.html') // serving path.join(__dirname, 'public', 'myHtml.html') directly
+  reply.sendFile('myHtml.html') // serving path.join(__dirname, 'public', 'myHtml.html') directly
+})
+
+fastify.get('another/patch-async', async function (req, reply) {
+  return reply.sendFile('myHtml.html')
 })
 
 fastify.get('/path/with/different/root', function (req, reply) {
-  return reply.sendFile('myHtml.html', path.join(__dirname, 'build')) // serving a file from a different root location
+  reply.sendFile('myHtml.html', path.join(__dirname, 'build')) // serving a file from a different root location
 })
 
 fastify.get('/another/path', function (req, reply) {
-  return reply.sendFile('myHtml.html', { cacheControl: false }) // overriding the options disabling cache-control headers
+  reply.sendFile('myHtml.html', { cacheControl: false }) // overriding the options disabling cache-control headers
 })
 ```
 
@@ -69,15 +73,19 @@ fastify.register(require('@fastify/static'), {
 })
 
 fastify.get('/another/path', function (req, reply) {
-  return reply.download('myHtml.html', 'custom-filename.html') // sending path.join(__dirname, 'public', 'myHtml.html') directly with custom filename
+  reply.download('myHtml.html', 'custom-filename.html') // sending path.join(__dirname, 'public', 'myHtml.html') directly with custom filename
+})
+
+fastify.get('another/patch-async', async function (req, reply) {
+  return reply.download('myHtml.html', 'custom-filename.html')
 })
 
 fastify.get('/path/without/cache/control', function (req, reply) {
-  return reply.download('myHtml.html', { cacheControl: false }) // serving a file disabling cache-control headers
+  reply.download('myHtml.html', { cacheControl: false }) // serving a file disabling cache-control headers
 })
 
 fastify.get('/path/without/cache/control', function (req, reply) {
-  return reply.download('myHtml.html', 'custom-filename.html', { cacheControl: false })
+  reply.download('myHtml.html', 'custom-filename.html', { cacheControl: false })
 })
 
 ```

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -808,7 +808,7 @@ t.test('serving disabled', (t) => {
   fastify.register(fastifyStatic, pluginOptions)
 
   fastify.get('/foo/bar', (request, reply) => {
-    return reply.sendFile('index.html')
+    reply.sendFile('index.html')
   })
 
   t.teardown(fastify.close.bind(fastify))
@@ -856,18 +856,18 @@ t.test('sendFile', (t) => {
   fastify.register(fastifyStatic, pluginOptions)
 
   fastify.get('/foo/bar', function (req, reply) {
-    return reply.sendFile('/index.html')
+    reply.sendFile('/index.html')
   })
 
   fastify.get('/root/path/override/test', (request, reply) => {
-    return reply.sendFile(
+    reply.sendFile(
       '/foo.html',
       path.join(__dirname, 'static', 'deep', 'path', 'for', 'test', 'purpose')
     )
   })
 
   fastify.get('/foo/bar/options/override/test', function (req, reply) {
-    return reply.sendFile('/index.html', { maxAge })
+    reply.sendFile('/index.html', { maxAge })
   })
 
   fastify.listen({ port: 0 }, (err) => {
@@ -1066,26 +1066,26 @@ t.test('download', (t) => {
   fastify.register(fastifyStatic, pluginOptions)
 
   fastify.get('/foo/bar', function (req, reply) {
-    return reply.download('/index.html')
+    reply.download('/index.html')
   })
 
   fastify.get('/foo/bar/change', function (req, reply) {
-    return reply.download('/index.html', 'hello-world.html')
+    reply.download('/index.html', 'hello-world.html')
   })
 
   fastify.get('/foo/bar/override', function (req, reply) {
-    return reply.download('/index.html', 'hello-world.html', {
+    reply.download('/index.html', 'hello-world.html', {
       maxAge: '2 hours',
       immutable: true
     })
   })
 
   fastify.get('/foo/bar/override/2', function (req, reply) {
-    return reply.download('/index.html', { acceptRanges: false })
+    reply.download('/index.html', { acceptRanges: false })
   })
 
   fastify.get('/root/path/override/test', (request, reply) => {
-    return reply.download('/foo.html', {
+    reply.download('/foo.html', {
       root: path.join(
         __dirname,
         'static',
@@ -1099,7 +1099,7 @@ t.test('download', (t) => {
   })
 
   fastify.get('/root/path/override/test/change', (request, reply) => {
-    return reply.download('/foo.html', 'hello-world.html', {
+    reply.download('/foo.html', 'hello-world.html', {
       root: path.join(
         __dirname,
         'static',


### PR DESCRIPTION
closes #332 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
