### PR TITLE
Fix/348 multi root and pre compression infinite loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ async function fastifyStatic (fastify, opts) {
             reply,
             pathname,
             rootPath,
-            undefined,
+            rootPathOffset,
             undefined,
             checkedEncodings
           )


### PR DESCRIPTION
Fixes #348 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Main changes

- detected the cause of the infinite loop when multi-root is active and preCompressed set to true:
    - the `rootPathOffset` was not being considered when calling recursively the `pumpSendToReply` after checking if `opts.preCompressed` and `!checkedEncodings.has(encoding)`
- added unit tests to verify the correct behaviour:
    - `will serve pre-compressed files with .gzip if multi-root`
    - `will still serve un-compressed files with multi-root and preCompressed as true`
    - if you restore the previous code in `index.js` and run the new unit tests, you will notice that they won't complete (infinite-loop)