### PR TITLE
fix: convert root parameters with URL object type to a path

### DIFF
--- a/test/static.test.js
+++ b/test/static.test.js
@@ -3703,3 +3703,50 @@ t.test(
     t.end()
   }
 )
+t.test(
+  'converts URL to path',
+  async (t) => {
+    t.plan(2 + GENERIC_RESPONSE_CHECK_COUNT)
+    const pluginOptions = {
+      root: url.pathToFileURL(path.join(__dirname, '/static'))
+    }
+
+    const fastify = Fastify()
+
+    fastify.register(fastifyStatic, pluginOptions)
+    const response = await fastify.inject({
+      method: 'GET',
+      url: 'foobar.html',
+      headers: {
+        'accept-encoding': '*, *'
+      }
+    })
+    genericResponseChecks(t, response)
+    t.equal(response.statusCode, 200)
+    t.same(response.body, foobarContent)
+  }
+)
+
+t.test(
+  'converts array of URLs to path, contains string path',
+  async (t) => {
+    t.plan(2 + GENERIC_RESPONSE_CHECK_COUNT)
+    const pluginOptions = {
+      root: [url.pathToFileURL(path.join(__dirname, '/static')), path.join(__dirname, 'static-dotfiles'), url.pathToFileURL(path.join(__dirname, '/static-pre-compressed'))]
+    }
+
+    const fastify = Fastify()
+
+    fastify.register(fastifyStatic, pluginOptions)
+    const response = await fastify.inject({
+      method: 'GET',
+      url: 'foobar.html',
+      headers: {
+        'accept-encoding': '*, *'
+      }
+    })
+    genericResponseChecks(t, response)
+    t.equal(response.statusCode, 200)
+    t.same(response.body, foobarContent)
+  }
+)


### PR DESCRIPTION
Fixed issue #364 by converting URL object types to a path.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark` (no benchmark script)
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
