### PR TITLE
Added parameters for custom glob patterns and glob options...

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ Glob pattern used to match files. Please read full description here: [Glob Prime
 
 Default: `{ nodir: true, dot: opts.serveDotFiles }`
 
-Options passed to glob module. All available optios are described here: [Glob Options](https://github.com/isaacs/node-glob#options)
+Options passed to glob module. All available options are described here: [Glob Options](https://github.com/isaacs/node-glob#options)
 
 #### Disable serving
 

--- a/README.md
+++ b/README.md
@@ -435,6 +435,18 @@ Assume this structure with the compressed asset as a sibling of the un-compresse
 └── index.html
 ```
 
+#### `globPattern`
+
+Default: `'**/**'`
+
+Glob pattern used to match files. Please read full description here: [Glob Primer](https://github.com/isaacs/node-glob#glob-primer)
+
+#### `globOptions`
+
+Default: `{ nodir: true, dot: opts.serveDotFiles }`
+
+Options passed to glob module. All available optios are described here: [Glob Options](https://github.com/isaacs/node-glob#options)
+
 #### Disable serving
 
 If you would just like to use the reply decorator and not serve whole directories automatically, you can simply pass the option `{ serve: false }`. This will prevent the plugin from serving everything under `root`.

--- a/index.js
+++ b/index.js
@@ -336,14 +336,15 @@ async function fastifyStatic (fastify, opts) {
         })
       }
     } else {
-      const globPattern = '**/**'
+      const globPattern = opts.globPattern !== undefined ? opts.globPattern : '**/**';
+      const globOptions =  typeof opts.globOptions === 'object' ? { ...{ nodir: true, dot: opts.serveDotFiles }, ...opts.globOptions } : { nodir: true, dot: opts.serveDotFiles }
       const indexDirs = new Map()
       const routes = new Set()
 
       const winSeparatorRegex = new RegExp(`\\${path.win32.sep}`, 'g')
 
       for (const rootPath of Array.isArray(sendOptions.root) ? sendOptions.root : [sendOptions.root]) {
-        const files = await globPromise(path.join(rootPath, globPattern).replace(winSeparatorRegex, path.posix.sep), { nodir: true, dot: opts.serveDotFiles })
+        const files = await globPromise(path.join(rootPath, globPattern).replace(winSeparatorRegex, path.posix.sep), globOptions)
         const indexes = typeof opts.index === 'undefined' ? ['index.html'] : [].concat(opts.index)
 
         for (let file of files) {

--- a/index.js
+++ b/index.js
@@ -336,8 +336,8 @@ async function fastifyStatic (fastify, opts) {
         })
       }
     } else {
-      const globPattern = opts.globPattern !== undefined ? opts.globPattern : '**/**'
-      const globOptions = typeof opts.globOptions === 'object' ? { ...{ nodir: true, dot: opts.serveDotFiles }, ...opts.globOptions } : { nodir: true, dot: opts.serveDotFiles }
+      const globPattern = opts.globPattern || '**/**'
+      const globOptions = opts.globOptions || { nodir: true, dot: opts.serveDotFiles }
       const indexDirs = new Map()
       const routes = new Set()
 

--- a/index.js
+++ b/index.js
@@ -336,8 +336,8 @@ async function fastifyStatic (fastify, opts) {
         })
       }
     } else {
-      const globPattern = opts.globPattern !== undefined ? opts.globPattern : '**/**';
-      const globOptions =  typeof opts.globOptions === 'object' ? { ...{ nodir: true, dot: opts.serveDotFiles }, ...opts.globOptions } : { nodir: true, dot: opts.serveDotFiles }
+      const globPattern = opts.globPattern !== undefined ? opts.globPattern : '**/**'
+      const globOptions = typeof opts.globOptions === 'object' ? { ...{ nodir: true, dot: opts.serveDotFiles }, ...opts.globOptions } : { nodir: true, dot: opts.serveDotFiles }
       const indexDirs = new Map()
       const routes = new Set()
 


### PR DESCRIPTION
 Added parameters for custom glob patterns and glob options, while also preserving backward compatibility with the serveDotFiles option provided by the plugin. As of https://github.com/fastify/fastify-static/issues/178

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
