### PR TITLE
Remove redundant parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -384,7 +384,7 @@ async function fastifyStatic (fastify, opts) {
       ...routeOpts,
       method: ['HEAD', 'GET'],
       url: route,
-      handler (req, reply) {
+      handler: function serveFileHandler (req, reply) {
         const file = req.routeConfig.file
         const rootPath = req.routeConfig.rootPath
         pumpSendToReply(req, reply, file, rootPath)

--- a/index.js
+++ b/index.js
@@ -474,8 +474,6 @@ function checkPath (fastify, rootPath) {
   }
 }
 
-const supportedEncodings = ['br', 'gzip', 'deflate']
-
 function getContentType (path) {
   const type = send.mime.getType(path) || send.mime.default_type
 
@@ -502,6 +500,8 @@ function findIndexFile (pathname, root, indexFiles = ['index.html']) {
   /* istanbul ignore next */
   return false
 }
+
+const supportedEncodings = ['br', 'gzip', 'deflate']
 
 // Adapted from https://github.com/fastify/fastify-compress/blob/665e132fa63d3bf05ad37df3c20346660b71a857/index.js#L451
 function getEncodingHeader (headers, checked) {

--- a/index.js
+++ b/index.js
@@ -384,16 +384,18 @@ async function fastifyStatic (fastify, opts) {
       ...routeOpts,
       method: ['HEAD', 'GET'],
       url: route,
-      handler: function serveFileHandler (req, reply) {
-        const file = req.routeConfig.file
-        const rootPath = req.routeConfig.rootPath
-        pumpSendToReply(req, reply, file, rootPath)
-      }
+      handler: serveFileHandler
     }
     toSetUp.config = toSetUp.config || {}
     toSetUp.config.file = file
     toSetUp.config.rootPath = rootPath
     fastify.route(toSetUp)
+  }
+
+  function serveFileHandler (req, reply) {
+    const file = req.routeConfig.file
+    const rootPath = req.routeConfig.rootPath
+    pumpSendToReply(req, reply, file, rootPath)
   }
 }
 


### PR DESCRIPTION
There is no need to pass the Fastify instance to `setUpHeadAndGet` as it already has access to it

This makes me wonder, for consistency purposes, why not put all the Fastify related functions inside the plugin function to avoid the need to pass `fastify`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
