### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Plugin for serving static files as fast as possible. Supports Fastify version `4
 
 ```js
 const fastify = require('fastify')({logger: true})
-const path = require('path')
+const path = require('node:path')
 
 fastify.register(require('@fastify/static'), {
   root: path.join(__dirname, 'public'),
@@ -57,7 +57,7 @@ fastify.listen({ port: 3000 }, (err, address) => {
 ```js
 const fastify = require('fastify')()
 const fastifyStatic = require('@fastify/static')
-const path = require('path')
+const path = require('node:path')
 // first plugin
 fastify.register(fastifyStatic, {
   root: path.join(__dirname, 'public')
@@ -76,7 +76,7 @@ fastify.register(fastifyStatic, {
 
 ```js
 const fastify = require('fastify')()
-const path = require('path')
+const path = require('node:path')
 
 fastify.register(require('@fastify/static'), {
   root: path.join(__dirname, 'public'),

--- a/example/server-compress.js
+++ b/example/server-compress.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const fastify = require('fastify')({ logger: { level: 'trace' } })
 
 fastify

--- a/example/server-dir-list.js
+++ b/example/server-dir-list.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const Handlebars = require('handlebars')
 
 const fastify = require('fastify')({ logger: { level: 'trace' } })

--- a/example/server-hidden-file.js
+++ b/example/server-hidden-file.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const fastify = require('fastify')({ logger: { level: 'trace' } })
 
 fastify

--- a/example/server.js
+++ b/example/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const fastify = require('fastify')({ logger: { level: 'trace' } })
 
 fastify

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const path = require('path')
-const { fileURLToPath } = require('url')
-const { statSync } = require('fs')
-const { promisify } = require('util')
+const path = require('node:path')
+const { fileURLToPath } = require('node:url')
+const { statSync } = require('node:fs')
+const { promisify } = require('node:util')
 const glob = require('glob')
 const globPromise = promisify(glob)
 const { PassThrough } = require('readable-stream')

--- a/lib/dirList.js
+++ b/lib/dirList.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const path = require('path')
-const fs = require('fs').promises
+const path = require('node:path')
+const fs = require('node:fs/promises')
 const pLimit = require('p-limit')
 
 const dirList = {

--- a/test/content-type.test.js
+++ b/test/content-type.test.js
@@ -2,7 +2,7 @@
 
 /* eslint n/no-deprecated-api: "off" */
 
-const path = require('path')
+const path = require('node:path')
 const { test } = require('tap')
 const simple = require('simple-get')
 const Fastify = require('fastify')

--- a/test/dir-list.test.js
+++ b/test/dir-list.test.js
@@ -2,8 +2,8 @@
 
 /* eslint n/no-deprecated-api: "off" */
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const t = require('tap')
 const simple = require('simple-get')
 const Fastify = require('fastify')

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -2823,7 +2823,7 @@ t.test(
   'register with rootpath that causes statSync to fail with non-ENOENT code',
   (t) => {
     const fastifyStatic = proxyquire('../', {
-      fs: {
+      'node:fs': {
         statSync: function statSyncStub (path) {
           throw new Error({ code: 'MOCK' })
         }

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -2,10 +2,10 @@
 
 /* eslint n/no-deprecated-api: "off" */
 
-const path = require('path')
-const fs = require('fs')
-const url = require('url')
-const http = require('http')
+const path = require('node:path')
+const fs = require('node:fs')
+const url = require('node:url')
+const http = require('node:http')
 const t = require('tap')
 const simple = require('simple-get')
 const Fastify = require('fastify')


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/37246/files#r588397158 and https://nodejs.org/api/modules.html#core-modules

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
