### PR TITLE
Fix request route config deprecation warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -552,7 +552,7 @@ function getRedirectUrl (url) {
 }
 
 module.exports = fp(fastifyStatic, {
-  fastify: '4.x',
+  fastify: '4.23.x',
   name: '@fastify/static'
 })
 module.exports.default = fastifyStatic

--- a/index.js
+++ b/index.js
@@ -552,7 +552,7 @@ function getRedirectUrl (url) {
 }
 
 module.exports = fp(fastifyStatic, {
-  fastify: '4.23.x',
+  fastify: '~4.23.0',
   name: '@fastify/static'
 })
 module.exports.default = fastifyStatic

--- a/index.js
+++ b/index.js
@@ -552,7 +552,7 @@ function getRedirectUrl (url) {
 }
 
 module.exports = fp(fastifyStatic, {
-  fastify: '~4.23.0',
+  fastify: '^4.23.0',
   name: '@fastify/static'
 })
 module.exports.default = fastifyStatic

--- a/index.js
+++ b/index.js
@@ -396,7 +396,7 @@ async function fastifyStatic (fastify, opts) {
   }
 
   function serveFileHandler (req, reply) {
-    const routeConfig = req.routeConfig
+    const routeConfig = req.routeOptions.config
     pumpSendToReply(req, reply, routeConfig.file, routeConfig.rootPath)
   }
 }


### PR DESCRIPTION
`request.routeConfig` has been deprecated in Fastify v4.23.0, which causes warnings in fastify-static.

This PR replaces the deprecated api with the recommended `request.routeOptions.config` property.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
