### PR TITLE
fix: allow fallback to fastify@2.22 route config

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,7 +398,7 @@ async function fastifyStatic (fastify, opts) {
   function serveFileHandler (req, reply) {
     // TODO: remove the fallback branch when bump major
     /* istanbul ignore next */
-    const routeConfig = (req.routeOptions && req.routeConfig.config) || req.routeConfig
+    const routeConfig = req.routeOptions?.config || req.routeConfig
     pumpSendToReply(req, reply, routeConfig.file, routeConfig.rootPath)
   }
 }

--- a/index.js
+++ b/index.js
@@ -396,7 +396,9 @@ async function fastifyStatic (fastify, opts) {
   }
 
   function serveFileHandler (req, reply) {
-    const routeConfig = req.routeOptions.config
+    // TODO: remove the fallback branch when bump major
+    /* istanbul ignore next */
+    const routeConfig = (req.routeOptions && req.routeConfig.config) || req.routeConfig
     pumpSendToReply(req, reply, routeConfig.file, routeConfig.rootPath)
   }
 }
@@ -552,7 +554,7 @@ function getRedirectUrl (url) {
 }
 
 module.exports = fp(fastifyStatic, {
-  fastify: '^4.23.0',
+  fastify: '4.x',
   name: '@fastify/static'
 })
 module.exports.default = fastifyStatic


### PR DESCRIPTION
Closes #411

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
