### PR TITLE
docs(readme): replace `fastify.io` links with `fastify.dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ This code will send the `index.html` for the paths `docs`, `docs/`, and `docs/in
 
 If an error occurs while trying to send a file, the error will be passed
 to Fastify's error handler. You can set a custom error handler with
-[`fastify.setErrorHandler()`](https://www.fastify.io/docs/latest/Reference/Server/#seterrorhandler).
+[`fastify.setErrorHandler()`](https://www.fastify.dev/docs/latest/Reference/Server/#seterrorhandler).
 
 ### Payload `stream.filename`
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ A URL path prefix used to create a virtual mount path for the static directory.
 Default: `{}`
 
 Constraints that will be added to registered routes. See Fastify's documentation for
-[route constraints](https://www.fastify.dev/docs/latest/Reference/Routes/#constraints).
+[route constraints](https://fastify.dev/docs/latest/Reference/Routes/#constraints).
 
 #### `prefixAvoidTrailingSlash`
 
@@ -450,7 +450,7 @@ decorators.
 
 If a request matches the URL `prefix` but a file cannot be found for the
 request, Fastify's 404 handler will be called. You can set a custom 404
-handler with [`fastify.setNotFoundHandler()`](https://www.fastify.dev/docs/latest/Reference/Server/#setnotfoundhandler).
+handler with [`fastify.setNotFoundHandler()`](https://fastify.dev/docs/latest/Reference/Server/#setnotfoundhandler).
 
 When registering `@fastify/static` within an encapsulated context, the `wildcard` option may need to be set to `false` in order to support index resolution and nested not-found-handler:
 
@@ -475,7 +475,7 @@ This code will send the `index.html` for the paths `docs`, `docs/`, and `docs/in
 
 If an error occurs while trying to send a file, the error will be passed
 to Fastify's error handler. You can set a custom error handler with
-[`fastify.setErrorHandler()`](https://www.fastify.dev/docs/latest/Reference/Server/#seterrorhandler).
+[`fastify.setErrorHandler()`](https://fastify.dev/docs/latest/Reference/Server/#seterrorhandler).
 
 ### Payload `stream.filename`
 


### PR DESCRIPTION
See https://github.com/fastify/ajv-compiler/pull/115

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
