### PR TITLE
chore: improve types for `setHeaders` option

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 //                 Leo <https://github.com/leomelzer>
 /// <reference types="node" />
 
-import { FastifyPluginAsync, FastifyRequest, RouteOptions } from 'fastify'
+import { FastifyPluginAsync, FastifyReply, FastifyRequest, RouteOptions } from 'fastify'
 import { Stats } from 'fs'
 
 declare module 'fastify' {
@@ -19,6 +19,13 @@ declare module 'fastify' {
 type FastifyStaticPlugin = FastifyPluginAsync<NonNullable<fastifyStatic.FastifyStaticOptions>>;
 
 declare namespace fastifyStatic {
+  export interface SetHeadersResponse {
+    getHeader: FastifyReply['getHeader'];
+    setHeader: FastifyReply['header'];
+    readonly filename: string;
+    statusCode: number;
+  }
+
   export interface ExtendedInformation {
     fileCount: number;
     totalFileCount: number;
@@ -83,7 +90,7 @@ declare namespace fastifyStatic {
     serve?: boolean;
     decorateReply?: boolean;
     schemaHide?: boolean;
-    setHeaders?: (...args: any[]) => void;
+    setHeaders?: (res: SetHeadersResponse, path: string, stat: Stats) => void;
     redirect?: boolean;
     wildcard?: boolean;
     list?: boolean | ListOptionsJsonFormat | ListOptionsHtmlFormat;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,5 +1,6 @@
-import fastify, { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify'
+import fastify, { FastifyInstance, FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify'
 import { Server } from 'http'
+import { Stats } from 'fs'
 import { expectAssignable, expectError, expectType } from 'tsd'
 import * as fastifyStaticStar from '..'
 import fastifyStatic, {
@@ -49,8 +50,15 @@ const options: FastifyStaticOptions = {
   serve: true,
   wildcard: true,
   list: false,
-  setHeaders: (res: any, pathName: any) => {
-    res.setHeader('test', pathName)
+  setHeaders: (res, path, stat) => {
+    expectType<string>(res.filename)
+    expectType<number>(res.statusCode)
+    expectType<ReturnType<FastifyReply['getHeader']>>(res.getHeader('X-Test'))
+    res.setHeader('X-Test', 'string')
+
+    expectType<string>(path)
+
+    expectType<Stats>(stat)
   },
   preCompressed: false,
   allowedPath: (pathName: string, root: string, request: FastifyRequest) => {


### PR DESCRIPTION
The arguments to the `setHeaders` option is currently `any[]`. This updates those types to be more specific.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
