### PR TITLE
fix: file not found errors when the root has a trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -384,7 +384,7 @@ async function fastifyStatic (fastify, opts) {
   function setUpHeadAndGet (routeOpts, route, file, rootPath) {
     const toSetUp = Object.assign({}, routeOpts, {
       exposeHeadRoute: true,
-      method: 'GET',
+      method: ['HEAD', 'GET'],
       url: route,
       handler: serveFileHandler
     })

--- a/index.js
+++ b/index.js
@@ -111,14 +111,11 @@ async function fastifyStatic (fastify, opts) {
       throw new Error('"wildcard" option must be a boolean')
     }
     if (opts.wildcard === undefined || opts.wildcard === true) {
-      fastify.route({
-        ...routeOpts,
-        exposeHeadRoute: true,
-        method: 'GET',
-        url: `${prefix}*`,
-        handler (req, reply) {
-          pumpSendToReply(req, reply, `/${req.params['*']}`, sendOptions.root)
-        }
+      fastify.head(prefix + '*', routeOpts, function (req, reply) {
+        pumpSendToReply(req, reply, '/' + req.params['*'], sendOptions.root)
+      })
+      fastify.get(prefix + '*', routeOpts, function (req, reply) {
+        pumpSendToReply(req, reply, '/' + req.params['*'], sendOptions.root)
       })
       if (opts.redirect === true && prefix !== opts.prefix) {
         fastify.get(opts.prefix, routeOpts, function (req, reply) {
@@ -383,7 +380,6 @@ async function fastifyStatic (fastify, opts) {
 
   function setUpHeadAndGet (routeOpts, route, file, rootPath) {
     const toSetUp = Object.assign({}, routeOpts, {
-      exposeHeadRoute: true,
       method: ['HEAD', 'GET'],
       url: route,
       handler: serveFileHandler

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ const contentDisposition = require('content-disposition')
 
 const dirList = require('./lib/dirList')
 
-const asteriskRegex = /\*/gu
 const endForwardSlashRegex = /\/$/u
+const asteriskRegex = /\*/gu
 
 const supportedEncodings = ['br', 'gzip', 'deflate']
 send.mime.default_type = 'application/octet-stream'

--- a/index.js
+++ b/index.js
@@ -111,14 +111,11 @@ async function fastifyStatic (fastify, opts) {
       throw new Error('"wildcard" option must be a boolean')
     }
     if (opts.wildcard === undefined || opts.wildcard === true) {
-      fastify.head(prefix + '*', routeOpts, function (req, reply) {
-        pumpSendToReply(req, reply, '/' + req.params['*'], sendOptions.root)
-      })
-      fastify.get(prefix + '*', routeOpts, function (req, reply) {
+      fastify.get(prefix + '*', { ...routeOpts, exposeHeadRoute: true }, (req, reply) => {
         pumpSendToReply(req, reply, '/' + req.params['*'], sendOptions.root)
       })
       if (opts.redirect === true && prefix !== opts.prefix) {
-        fastify.get(opts.prefix, routeOpts, function (req, reply) {
+        fastify.get(opts.prefix, routeOpts, (req, reply) => {
           reply.redirect(301, getRedirectUrl(req.raw.url))
         })
       }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const { PassThrough } = require('node:stream')
 const path = require('node:path')
 const { fileURLToPath } = require('node:url')
 const { statSync } = require('node:fs')
-const { Glob } = require('glob')
+const { glob } = require('glob')
 const fp = require('fastify-plugin')
 const send = require('@fastify/send')
 const encodingNegotiator = require('@fastify/accept-negotiator')
@@ -135,11 +135,11 @@ async function fastifyStatic (fastify, opts) {
         rootPath = rootPath.split(path.win32.sep).join(path.posix.sep)
         !rootPath.endsWith('/') && (rootPath += '/')
 
-        const filesIterable = new Glob('**/**', {
+        const files = await glob('**/**', {
           cwd: rootPath, absolute: false, follow: true, nodir: true, dot: opts.serveDotFiles
         })
 
-        for (let file of filesIterable) {
+        for (let file of files) {
           file = file.split(path.win32.sep).join(path.posix.sep)
           const route = prefix + file
 

--- a/index.js
+++ b/index.js
@@ -134,7 +134,6 @@ async function fastifyStatic (fastify, opts) {
       for (let rootPath of roots) {
         rootPath = rootPath.split(path.win32.sep).join(path.posix.sep)
         !rootPath.endsWith('/') && (rootPath += '/')
-
         const files = await glob('**/**', {
           cwd: rootPath, absolute: false, follow: true, nodir: true, dot: opts.serveDotFiles
         })


### PR DESCRIPTION
It currently does not handle a root with a trailing slash correctly