### PR TITLE
fix: wildcard head return content-length header

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,8 +111,13 @@ async function fastifyStatic (fastify, opts) {
       throw new Error('"wildcard" option must be a boolean')
     }
     if (opts.wildcard === undefined || opts.wildcard === true) {
-      fastify.get(prefix + '*', { ...routeOpts, exposeHeadRoute: true }, (req, reply) => {
-        pumpSendToReply(req, reply, '/' + req.params['*'], sendOptions.root)
+      fastify.route({
+        ...routeOpts,
+        method: ['HEAD', 'GET'],
+        path: prefix + '*',
+        handler (req, reply) {
+          pumpSendToReply(req, reply, '/' + req.params['*'], sendOptions.root)
+        }
       })
       if (opts.redirect === true && prefix !== opts.prefix) {
         fastify.get(opts.prefix, routeOpts, (req, reply) => {

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1740,7 +1740,7 @@ t.test('with fastify-compress', t => {
   })
 })
 t.test('register /static/ with schemaHide true', t => {
-  t.plan(4)
+  t.plan(3)
 
   const pluginOptions = {
     root: path.join(__dirname, '/static'),
@@ -1780,7 +1780,7 @@ t.test('register /static/ with schemaHide true', t => {
 })
 
 t.test('register /static/ with schemaHide false', t => {
-  t.plan(4)
+  t.plan(3)
 
   const pluginOptions = {
     root: path.join(__dirname, '/static'),
@@ -1820,7 +1820,7 @@ t.test('register /static/ with schemaHide false', t => {
 })
 
 t.test('register /static/ without schemaHide', t => {
-  t.plan(4)
+  t.plan(3)
 
   const pluginOptions = {
     root: path.join(__dirname, '/static'),
@@ -2957,7 +2957,7 @@ t.test('inject support', async (t) => {
 })
 
 t.test('routes should use custom errorHandler premature stream close', t => {
-  t.plan(4)
+  t.plan(3)
 
   const pluginOptions = {
     root: path.join(__dirname, '/static'),
@@ -2992,7 +2992,7 @@ t.test('routes should use custom errorHandler premature stream close', t => {
 })
 
 t.test('routes should fallback to default errorHandler', t => {
-  t.plan(4)
+  t.plan(3)
 
   const pluginOptions = {
     root: path.join(__dirname, '/static'),
@@ -3962,3 +3962,37 @@ t.test(
     t.same(response2.body, aContent)
   }
 )
+
+t.test('content-length in head route should not return zero when using wildcard', t => {
+  t.plan(6)
+
+  const pluginOptions = {
+    root: path.join(__dirname, '/static')
+  }
+  const fastify = Fastify()
+
+  fastify.register(fastifyStatic, pluginOptions)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    fastify.server.unref()
+
+    const file = fs.readFileSync(path.join(__dirname, '/static/index.html'))
+    const contentLength = Buffer.byteLength(file).toString()
+
+    simple.concat({
+      method: 'HEAD',
+      url: 'http://localhost:' + fastify.server.address().port + '/index.html',
+      followRedirect: false
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-type'], 'text/html; charset=UTF-8')
+      t.equal(response.headers['content-length'], contentLength)
+      t.equal(body.toString(), '')
+    })
+  })
+})


### PR DESCRIPTION
Fixes #447 

The reason behind we should not use `exposeHeadRoute` is that inside `pumpSendToReply`, we never provide `payload` for `HEAD` route. So, `fastify` think it is providing `empty` response and override the `Content-Length` unexpectedly.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
