### PR TITLE
fix: disable root path check when serve is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ send.mime.default_type = 'application/octet-stream'
 
 async function fastifyStatic (fastify, opts) {
   opts.root = normalizeRoot(opts.root)
-  checkRootPathForErrors(fastify, opts.root)
+  checkRootPathForErrors(fastify, opts.root, opts.serve);
 
   const setHeaders = opts.setHeaders
   if (setHeaders !== undefined && typeof setHeaders !== 'function') {
@@ -408,7 +408,11 @@ function normalizeRoot (root) {
   return root
 }
 
-function checkRootPathForErrors (fastify, rootPath) {
+function checkRootPathForErrors(fastify, rootPath, serve = true) {
+  if (serve === false) {
+    return;
+  }
+
   if (rootPath === undefined) {
     throw new Error('"root" option is required')
   }

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -4023,3 +4023,51 @@ t.test('content-length in head route should not return zero when using wildcard'
     })
   })
 })
+
+t.test('serve: false disables root path check', (t) => {
+  t.plan(3)
+
+  const pluginOptions = {
+    root: path.join(__dirname, '/static'),
+    prefix: '/static',
+    serve: false
+  };
+  const fastify = Fastify();
+  fastify.register(fastifyStatic, pluginOptions);
+
+  t.teardown(fastify.close.bind(fastify));
+
+  fastify.listen({ port: 0 }, (err) => {
+    t.error(err);
+
+    fastify.server.unref();
+
+    t.test('/static/index.html', (t) => {
+      t.plan(2 + GENERIC_ERROR_RESPONSE_CHECK_COUNT);
+      simple.concat({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port + '/static/index.html'
+      }, (err, response, body) => {
+        t.error(err);
+        t.equal(response.statusCode, 404);
+        genericErrorResponseChecks(t, response);
+        t.end()
+      });
+    });
+
+    t.test('/static/deep/path/for/test/purpose/foo.html', (t) => {
+      t.plan(2 + GENERIC_ERROR_RESPONSE_CHECK_COUNT);
+      simple.concat({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port + '/static/deep/path/for/test/purpose/foo.html'
+      }, (err, response, body) => {
+        t.error(err);
+        t.equal(response.statusCode, 404);
+        genericErrorResponseChecks(t, response);
+        t.end()
+      });
+    });
+
+    t.end()
+  });
+});


### PR DESCRIPTION
### Summary
This MR addresses the issue where the `checkRootPathForErrors` function still requires a valid path to root even when `serve: false` is set. 

### Changes
- Disabled `checkRootPathForErrors` when `serve: false`.
- Added a unit test to confirm that the root path check is bypassed when `serve: false`.

### Tests
- Added a test in `test/static.js` to verify that `checkRootPathForErrors` is not called when `serve: false`.

This fix allows users to use the `sendFile` decorator without needing to serve static files, as requested.
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
