### PR TITLE
feature: disable root path check when serve is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,13 +437,12 @@ Assume this structure with the compressed asset as a sibling of the un-compresse
 
 #### Disable serving and CWD behavior
 
-If you would just like to use the reply decorator and not serve whole directories automatically, you can simply pass the option `{ serve: false }`. This will prevent the plugin from serving everything under `root`.
+If you want to use only the reply decorator without automatically serving whole directories, pass the option `{ serve: false }`. This prevents the plugin from serving everything under `root`.
 
-When `serve: false` is passed:
+When `serve: false` is used:
 
-1. The plugin will not perform the usual directory existence check for the `root` option.
-2. If no `root` is provided, the plugin will default to using the current working directory (CWD) as the root.
-3. A warning will be logged if no `root` is provided, informing that the CWD is being used as the default.
+- If no `root` is provided, the plugin will use the current working directory (CWD) as the default root.
+- The `sendFile` method will send files relative to the CWD or the specified `root`.
 
 Example usage:
 
@@ -463,7 +462,7 @@ fastify.get('/file', (req, reply) => {
 })
 ```
 
-This configuration allows you to use the `sendFile` decorator without automatically serving an entire directory, giving you more control over which files are accessible.
+This configuration allows you to use the `sendFile` decorator without automatically serving an entire directory.
 
 #### Disabling reply decorator
 

--- a/README.md
+++ b/README.md
@@ -435,9 +435,35 @@ Assume this structure with the compressed asset as a sibling of the un-compresse
 └── index.html
 ```
 
-#### Disable serving
+#### Disable serving and CWD behavior
 
 If you would just like to use the reply decorator and not serve whole directories automatically, you can simply pass the option `{ serve: false }`. This will prevent the plugin from serving everything under `root`.
+
+When `serve: false` is passed:
+
+1. The plugin will not perform the usual directory existence check for the `root` option.
+2. If no `root` is provided, the plugin will default to using the current working directory (CWD) as the root.
+3. A warning will be logged if no `root` is provided, informing that the CWD is being used as the default.
+
+Example usage:
+
+```js
+const fastify = require('fastify')()
+const path = require('node:path')
+
+fastify.register(require('@fastify/static'), {
+  serve: false,
+  // root is optional when serve is false, will default to CWD if not provided
+  root: path.join(__dirname, 'public')
+})
+
+fastify.get('/file', (req, reply) => {
+  // This will serve the file from the CWD if no root was provided
+  reply.sendFile('myFile.html')
+})
+```
+
+This configuration allows you to use the `sendFile` decorator without automatically serving an entire directory, giving you more control over which files are accessible.
 
 #### Disabling reply decorator
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ send.mime.default_type = 'application/octet-stream'
 
 async function fastifyStatic (fastify, opts) {
   opts.root = normalizeRoot(opts.root)
-  checkRootPathForErrors(fastify, opts.root)
+  checkRootPathForErrors(fastify, opts.root, opts.serve)
 
   const setHeaders = opts.setHeaders
   if (setHeaders !== undefined && typeof setHeaders !== 'function') {
@@ -408,7 +408,11 @@ function normalizeRoot (root) {
   return root
 }
 
-function checkRootPathForErrors (fastify, rootPath) {
+function checkRootPathForErrors (fastify, rootPath, serve = true) {
+  if (serve === false) {
+    return
+  }
+
   if (rootPath === undefined) {
     throw new Error('"root" option is required')
   }

--- a/index.js
+++ b/index.js
@@ -442,6 +442,10 @@ function checkRootPathForErrors (fastify, rootPath, skipExistenceCheck) {
 }
 
 function checkPath (fastify, rootPath, skipExistenceCheck) {
+  // skip all checks if rootPath is the CWD
+  if (rootPath === process.cwd()) {
+    return
+  }
   if (typeof rootPath !== 'string') {
     throw new Error('"root" option must be a string')
   }

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -4023,3 +4023,51 @@ t.test('content-length in head route should not return zero when using wildcard'
     })
   })
 })
+
+t.test('serve: false disables root path check', (t) => {
+  t.plan(3)
+
+  const pluginOptions = {
+    root: path.join(__dirname, '/static'),
+    prefix: '/static',
+    serve: false
+  }
+  const fastify = Fastify()
+  fastify.register(fastifyStatic, pluginOptions)
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.listen({ port: 0 }, (err) => {
+    t.error(err)
+
+    fastify.server.unref()
+
+    t.test('/static/index.html', (t) => {
+      t.plan(2 + GENERIC_ERROR_RESPONSE_CHECK_COUNT)
+      simple.concat({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port + '/static/index.html'
+      }, (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 404)
+        genericErrorResponseChecks(t, response)
+        t.end()
+      })
+    })
+
+    t.test('/static/deep/path/for/test/purpose/foo.html', (t) => {
+      t.plan(2 + GENERIC_ERROR_RESPONSE_CHECK_COUNT)
+      simple.concat({
+        method: 'GET',
+        url: 'http://localhost:' + fastify.server.address().port + '/static/deep/path/for/test/purpose/foo.html'
+      }, (err, response, body) => {
+        t.error(err)
+        t.equal(response.statusCode, 404)
+        genericErrorResponseChecks(t, response)
+        t.end()
+      })
+    })
+
+    t.end()
+  })
+})


### PR DESCRIPTION
### Summary
This MR addresses the issue [#460](https://github.com/fastify/fastify-static/issues/460) where the `checkRootPathForErrors` function still requires a valid path to root even when `serve: false` is set. 

### Changes
- Disabled `checkRootPathForErrors` when `serve: false`.
- Added a unit test to confirm that the root path check is bypassed when `serve: false`.

### Tests
- Added a test in `test/static.js` to verify that `checkRootPathForErrors` is not called when `serve: false`.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
