### PR TITLE
fix: respect custom status code when successfully send file

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,7 +350,11 @@ async function fastifyStatic (fastify, opts) {
         break
       }
       case 'file': {
-        reply.code(statusCode)
+        // reply.raw.statusCode by default 200
+        // when ever the user changed it, we respect the status code
+        // otherwise use send provided status code
+        const newStatusCode = reply.statusCode !== 200 ? reply.statusCode : statusCode
+        reply.code(newStatusCode)
         if (setHeaders !== undefined) {
           setHeaders(reply.raw, metadata.path, metadata.stat)
         }


### PR DESCRIPTION
Fix #474

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
