### PR TITLE
docs(readme): update send links

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,17 +153,17 @@ where the arguments are:
 #### `send` Options
 
 The following options are also supported and will be passed directly to the
-[`send`](https://www.npmjs.com/package/send) module:
+[`@fastify/send`](https://www.npmjs.com/package/@fastify/send) module:
 
-- [`acceptRanges`](https://www.npmjs.com/package/send#acceptranges)
-- [`cacheControl`](https://www.npmjs.com/package/send#cachecontrol) (Enable or disable setting Cache-Control response header, defaults to true. **Important:** If you want to provide a custom Cache-Control response header, this option must be false.)
-- [`dotfiles`](https://www.npmjs.com/package/send#dotfiles)
-- [`etag`](https://www.npmjs.com/package/send#etag)
-- [`extensions`](https://www.npmjs.com/package/send#extensions)
-- [`immutable`](https://www.npmjs.com/package/send#immutable)
-- [`index`](https://www.npmjs.com/package/send#index)
-- [`lastModified`](https://www.npmjs.com/package/send#lastmodified)
-- [`maxAge`](https://www.npmjs.com/package/send#maxage)
+- [`acceptRanges`](https://www.npmjs.com/package/@fastify/send#acceptranges)
+- [`cacheControl`](https://www.npmjs.com/package/@fastify/send#cachecontrol) (Enable or disable setting Cache-Control response header, defaults to true. **Important:** If you want to provide a custom Cache-Control response header, this option must be false.)
+- [`dotfiles`](https://www.npmjs.com/package/@fastify/send#dotfiles)
+- [`etag`](https://www.npmjs.com/package/@fastify/send#etag)
+- [`extensions`](https://www.npmjs.com/package/@fastify/send#extensions)
+- [`immutable`](https://www.npmjs.com/package/@fastify/send#immutable)
+- [`index`](https://www.npmjs.com/package/@fastify/send#index)
+- [`lastModified`](https://www.npmjs.com/package/@fastify/send#lastmodified)
+- [`maxAge`](https://www.npmjs.com/package/@fastify/send#maxage)
 
 You're able to alter this options when calling `reply.download('filename.html', options)` or `reply.download('filename.html', 'otherfilename.html', options)` on each response to a request.
 


### PR DESCRIPTION
`@fastify/static` uses `@fastify/send` not the original `send` package.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
