### PR TITLE
fix: add `contentType` send option

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The following options are also supported and will be passed directly to the
 [`@fastify/send`](https://www.npmjs.com/package/@fastify/send) module:
 
 - [`acceptRanges`](https://www.npmjs.com/package/@fastify/send#acceptranges)
+- [`contentType`](https://www.npmjs.com/package/@fastify/send#contenttype)
 - [`cacheControl`](https://www.npmjs.com/package/@fastify/send#cachecontrol) (Enable or disable setting Cache-Control response header, defaults to true. **Important:** If you want to provide a custom Cache-Control response header, this option must be false.)
 - [`dotfiles`](https://www.npmjs.com/package/@fastify/send#dotfiles)
 - [`etag`](https://www.npmjs.com/package/@fastify/send#etag)

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ async function fastifyStatic (fastify, opts) {
   const sendOptions = {
     root: opts.root,
     acceptRanges: opts.acceptRanges,
+    contentType: opts.contentType,
     cacheControl: opts.cacheControl,
     dotfiles: opts.dotfiles,
     etag: opts.etag,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/fastify/fastify-static",
   "dependencies": {
     "@fastify/accept-negotiator": "^2.0.0",
-    "@fastify/send": "^3.1.0",
+    "@fastify/send": "^3.2.0",
     "content-disposition": "^0.5.4",
     "fastify-plugin": "^5.0.0",
     "fastq": "^1.17.1",

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1377,10 +1377,11 @@ t.test('root not found warning', (t) => {
 })
 
 t.test('send options', (t) => {
-  t.plan(11)
+  t.plan(12)
   const pluginOptions = {
     root: path.join(__dirname, '/static'),
     acceptRanges: 'acceptRanges',
+    contentType: 'contentType',
     cacheControl: 'cacheControl',
     dotfiles: 'dotfiles',
     etag: 'etag',
@@ -1396,6 +1397,7 @@ t.test('send options', (t) => {
       t.equal(pathName, '/index.html')
       t.equal(options.root, path.join(__dirname, '/static'))
       t.equal(options.acceptRanges, 'acceptRanges')
+      t.equal(options.contentType, 'contentType')
       t.equal(options.cacheControl, 'cacheControl')
       t.equal(options.dotfiles, 'dotfiles')
       t.equal(options.etag, 'etag')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -72,6 +72,7 @@ declare namespace fastifyStatic {
   // Passed on to `send`
   export interface SendOptions {
     acceptRanges?: boolean;
+    contentType?: boolean;
     cacheControl?: boolean;
     dotfiles?: 'allow' | 'deny' | 'ignore';
     etag?: boolean;
@@ -103,6 +104,7 @@ declare namespace fastifyStatic {
 
     // Passed on to `send`
     acceptRanges?: boolean;
+    contentType?: boolean;
     cacheControl?: boolean;
     dotfiles?: 'allow' | 'deny' | 'ignore';
     etag?: boolean;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -146,6 +146,10 @@ appWithHttp2
     appWithHttp2.get('/download/2', (request, reply) => {
       reply.download('some-file-name', 'some-filename', { cacheControl: false, acceptRanges: true })
     })
+
+    appWithHttp2.get('/download/3', (request, reply) => {
+      reply.download('some-file-name', 'some-filename', { contentType: false })
+    })
   })
 
 const multiRootAppWithImplicitHttp = fastify()
@@ -166,6 +170,10 @@ multiRootAppWithImplicitHttp
       reply.sendFile('some-file-name', 'some-root-name', { cacheControl: false, acceptRanges: true })
     })
 
+    multiRootAppWithImplicitHttp.get('/', (request, reply) => {
+      reply.sendFile('some-file-name', 'some-root-name-2', { contentType: false })
+    })
+
     multiRootAppWithImplicitHttp.get('/download', (request, reply) => {
       reply.download('some-file-name')
     })
@@ -176,6 +184,10 @@ multiRootAppWithImplicitHttp
 
     multiRootAppWithImplicitHttp.get('/download/2', (request, reply) => {
       reply.download('some-file-name', 'some-filename', { cacheControl: false, acceptRanges: true })
+    })
+
+    multiRootAppWithImplicitHttp.get('/download/3', (request, reply) => {
+      reply.download('some-file-name', 'some-filename', { contentType: false })
     })
   })
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -34,6 +34,7 @@ expectType<any>(fastifyStaticCjs)
 const appWithImplicitHttp = fastify()
 const options: FastifyStaticOptions = {
   acceptRanges: true,
+  contentType: true,
   cacheControl: true,
   decorateReply: true,
   dotfiles: 'allow',


### PR DESCRIPTION
Added as part of [v3.2.0 of `@fastify/send`](https://github.com/fastify/send/releases/tag/v3.2.0).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
