### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@
 /// <reference types="node" />
 
 import { FastifyPluginAsync, FastifyReply, FastifyRequest, RouteOptions } from 'fastify'
-import { Stats } from 'fs'
+import { Stats } from 'node:fs'
 
 declare module 'fastify' {
   interface FastifyReply {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,6 +1,6 @@
 import fastify, { FastifyInstance, FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify'
-import { Server } from 'http'
-import { Stats } from 'fs'
+import { Server } from 'node:http'
+import { Stats } from 'node:fs'
 import { expectAssignable, expectError, expectType } from 'tsd'
 import * as fastifyStaticStar from '..'
 import fastifyStatic, {


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.