### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
     "concat-stream": "^2.0.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.1.0",
     "neostandard": "^0.12.0",
     "pino": "^9.1.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.