### PR TITLE
Add example of sane cache-control settings when hosting a vite SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,31 @@ fastify.get('/path/without/cache/control', function (req, reply) {
 
 ```
 
+### Managing cache-control headers
+
+Production sites should use a reverse-proxy to manage caching headers.
+However, here is an example of using fastify-static to host a Single Page Application (for example a [vite.js](https://vite.dev/) build) with sane caching.
+
+```js
+fastify.register(require('@fastify/static'), {
+  root: path.join(import.meta.dirname, 'dist'), // import.meta.dirname node.js >= v20.11.0
+  // By default all assets are immutable and can be cached for a long period due to cache bursting techniques
+  maxAge: '30d',
+  immutable: true,
+})
+
+// Explicitly reduce caching of assets that don't use cache bursting techniques
+fastify.get('/', function (req, reply) {
+  // index.html should never be cached
+  reply.sendFile('index.html', {maxAge: 0, immutable: false})
+})
+
+fastify.get('/favicon.ico', function (req, reply) {
+  // favicon can be cached for a short period
+  reply.sendFile('index.html', {maxAge: '1d', immutable: false})
+})
+```
+
 ### Options
 
 #### `root` (required)


### PR DESCRIPTION
Adds a sane example of how one might setup the cache-control headers when using fastify-static to host a site, in particular a site built with vite.js

I've been burnt by this recently and I thought it could help others if it was front and center in the docs. In particular, looking at the existing examples, one might think that setting `cacheControl: false` will disable caching when in fact it will simply disable setting the header and let the browser to it's default caching (which is rarely the desired outcome). 

related to #508 & #477

Not sure if this merits an example front in center in the readme, but it would have saved me some headache in some personal projects.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
