### PR TITLE
docs: use cross-platform compatible info emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Default: `['']`
 
 Directory list can respond to different routes declared in `list.names`.
 
-> 🛈 Note: If a file with the same name exists, the actual file is sent.
+> ℹ️ Note: If a file with the same name exists, the actual file is sent.
 
 Example:
 


### PR DESCRIPTION
Previous icon was not visible in Safari. See https://github.com/fastify/fastify/pull/6132#discussion_r2097602170