### PR TITLE
Adding an option to modify the non-existent root directory warning (#524)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ A custom function that returns a warning message to log when a specified root di
 It receives a single argument: the path of the missing root directory.
 The function should return a string describing the missing path.
 
+#### `suppressPathNotFoundWarning`
+
+If set to `true`, this option disables the warning message when a specified root directory is not found.
+
 #### `prefix`
 
 Default: `'/'`

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ An array of directories can be provided to serve multiple static directories
 under a single prefix. Files are served in a "first found, first served" manner,
 so list directories in order of priority. Duplicate paths will raise an error.
 
+#### `getPathNotFoundWarning`
+
+A custom function that returns a warning message to log when a specified root directory is not found.
+It receives a single argument: the path of the missing root directory.
+The function should return a string describing the missing path.
+
 #### `prefix`
 
 Default: `'/'`

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1123,6 +1123,30 @@ test('root not found warning', async (t) => {
   destination.end()
 })
 
+test('suppressing root not found warning', async (t) => {
+  t.plan(1)
+  const rootPath = path.join(__dirname, 'does-not-exist')
+  const pluginOptions = {
+    root: rootPath,
+    suppressPathNotFoundWarning: true
+  }
+  const destination = concat((data) => {
+    t.assert.deepStrictEqual(data, [])
+  })
+  const loggerInstance = pino(
+    {
+      level: 'warn'
+    },
+    destination
+  )
+  const fastify = Fastify({ loggerInstance })
+  fastify.register(fastifyStatic, pluginOptions)
+
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
+  destination.end()
+})
+
 test('custom root not found warning', async (t) => {
   t.plan(1)
   const rootPath = path.join(__dirname, 'does-not-exist')

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1123,6 +1123,30 @@ test('root not found warning', async (t) => {
   destination.end()
 })
 
+test('custom root not found warning', async (t) => {
+  t.plan(1)
+  const rootPath = path.join(__dirname, 'does-not-exist')
+  const pluginOptions = {
+    root: rootPath,
+    getPathNotFoundWarning: (path) => `CUSTOM "root" path "${path}" must exist`,
+  }
+  const destination = concat((data) => {
+    t.assert.deepStrictEqual(JSON.parse(data).msg, `CUSTOM "root" path "${rootPath}" must exist`)
+  })
+  const loggerInstance = pino(
+    {
+      level: 'warn'
+    },
+    destination
+  )
+  const fastify = Fastify({ loggerInstance })
+  fastify.register(fastifyStatic, pluginOptions)
+
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
+  destination.end()
+})
+
 test('send options', (t) => {
   t.plan(12)
   const pluginOptions = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,6 +86,7 @@ declare namespace fastifyStatic {
 
   export interface FastifyStaticOptions extends SendOptions {
     root: string | string[] | URL | URL[];
+    getPathNotFoundWarning?: (path: string) => string;
     prefix?: string;
     prefixAvoidTrailingSlash?: boolean;
     serve?: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -87,6 +87,7 @@ declare namespace fastifyStatic {
   export interface FastifyStaticOptions extends SendOptions {
     root: string | string[] | URL | URL[];
     getPathNotFoundWarning?: (path: string) => string;
+    suppressPathNotFoundWarning?: boolean;
     prefix?: string;
     prefixAvoidTrailingSlash?: boolean;
     serve?: boolean;


### PR DESCRIPTION
I have added an option to change the default warning message when the root directory (or one of the root directories) is not found. (#524)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
