### PR TITLE
feat: make root optional when serve is false #460

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,7 +399,7 @@ async function fastifyStatic (fastify, opts) {
   }
 
   /** @type {import("fastify").RouteHandlerMethod} */
-  async function serveFileHandler(req, reply) {
+  async function serveFileHandler (req, reply) {
     const routeConfig = req.routeOptions?.config
     return pumpSendToReply(req, reply, routeConfig.file, routeConfig.rootPath)
   }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const supportedEncodings = ['br', 'gzip', 'deflate']
 send.mime.default_type = 'application/octet-stream'
 
 /** @type {import("fastify").FastifyPluginAsync<import("./types").FastifyStaticOptions>} */
-async function fastifyStatic(fastify, opts) {
+async function fastifyStatic (fastify, opts) {
   if (opts.serve !== false) {
     opts.root = normalizeRoot(opts.root)
     checkRootPathForErrors(fastify, opts.root)
@@ -68,7 +68,7 @@ async function fastifyStatic(fastify, opts) {
       hide: opts.schemaHide !== undefined ? opts.schemaHide : true
     },
     logLevel: opts.logLevel,
-    errorHandler(error, request, reply) {
+    errorHandler (error, request, reply) {
       if (error?.code === 'ERR_STREAM_PREMATURE_CLOSE') {
         reply.request.raw.destroy()
         return
@@ -119,7 +119,7 @@ async function fastifyStatic(fastify, opts) {
         ...routeOpts,
         method: ['HEAD', 'GET'],
         path: prefix + '*',
-        handler(req, reply) {
+        handler (req, reply) {
           pumpSendToReply(req, reply, '/' + req.params['*'], sendOptions.root)
         }
       })
@@ -183,7 +183,7 @@ async function fastifyStatic(fastify, opts) {
    * @param {import("@fastify/send").SendOptions} [pumpOptions]
    * @param {Set<string>} [checkedEncodings]
    */
-  async function pumpSendToReply(
+  async function pumpSendToReply (
     request,
     reply,
     pathname,
@@ -301,7 +301,7 @@ async function fastifyStatic(fastify, opts) {
         }
 
         if (metadata.error.code === 'ENOENT') {
-          // when preCompress is enabled and the path is a directory without a trailing slash
+        // when preCompress is enabled and the path is a directory without a trailing slash
           if (opts.preCompressed && encoding) {
             if (opts.redirect !== true) {
               const indexPathname = findIndexFile(pathname, options.root, options.index)
@@ -386,7 +386,7 @@ async function fastifyStatic(fastify, opts) {
     }
   }
 
-  function setUpHeadAndGet(routeOpts, route, file, rootPath) {
+  function setUpHeadAndGet (routeOpts, route, file, rootPath) {
     const toSetUp = Object.assign({}, routeOpts, {
       method: ['HEAD', 'GET'],
       url: route,
@@ -409,7 +409,7 @@ async function fastifyStatic(fastify, opts) {
  * @param {import("./types").FastifyStaticOptions['root']} root
  * @returns {import("./types").FastifyStaticOptions['root']}
  */
-function normalizeRoot(root) {
+function normalizeRoot (root) {
   if (root === undefined) {
     return root
   }
@@ -437,7 +437,7 @@ function normalizeRoot(root) {
  * @param {import("./types").FastifyStaticOptions['root']} rootPath
  * @returns {void}
  */
-function checkRootPathForErrors(fastify, rootPath) {
+function checkRootPathForErrors (fastify, rootPath) {
   if (rootPath === undefined) {
     throw new Error('"root" option is required')
   }
@@ -470,7 +470,7 @@ function checkRootPathForErrors(fastify, rootPath) {
  * @param {import("./types").FastifyStaticOptions['root']} rootPath
  * @returns {void}
  */
-function checkPath(fastify, rootPath) {
+function checkPath (fastify, rootPath) {
   if (typeof rootPath !== 'string') {
     throw new TypeError('"root" option must be a string')
   }
@@ -500,7 +500,7 @@ function checkPath(fastify, rootPath) {
  * @param {string} path
  * @return {string}
  */
-function getContentType(path) {
+function getContentType (path) {
   const type = send.mime.getType(path) || send.mime.default_type
 
   if (!send.isUtf8MimeType(type)) {
@@ -515,7 +515,7 @@ function getContentType(path) {
  * @param {import("./types").FastifyStaticOptions['index']} [indexFiles]
  * @return {string|boolean}
  */
-function findIndexFile(pathname, root, indexFiles = ['index.html']) {
+function findIndexFile (pathname, root, indexFiles = ['index.html']) {
   if (Array.isArray(indexFiles)) {
     return indexFiles.find(filename => {
       const p = path.join(root, pathname, filename)
@@ -536,7 +536,7 @@ function findIndexFile(pathname, root, indexFiles = ['index.html']) {
  * @param {import('fastify').FastifyRequest['headers']} headers
  * @param {Set<string>} checked
  */
-function getEncodingHeader(headers, checked) {
+function getEncodingHeader (headers, checked) {
   if (!('accept-encoding' in headers)) return
 
   // consider the no-preference token as gzip for downstream compat
@@ -552,7 +552,7 @@ function getEncodingHeader(headers, checked) {
  * @param {string} encoding
  * @returns {string}
  */
-function getEncodingExtension(encoding) {
+function getEncodingExtension (encoding) {
   switch (encoding) {
     case 'br':
       return 'br'
@@ -566,7 +566,7 @@ function getEncodingExtension(encoding) {
  * @param {string} url
  * @return {string}
  */
-function getRedirectUrl(url) {
+function getRedirectUrl (url) {
   let i = 0
   // we detect how many slash before a valid path
   for (; i < url.length; ++i) {

--- a/index.js
+++ b/index.js
@@ -18,9 +18,11 @@ const supportedEncodings = ['br', 'gzip', 'deflate']
 send.mime.default_type = 'application/octet-stream'
 
 /** @type {import("fastify").FastifyPluginAsync<import("./types").FastifyStaticOptions>} */
-async function fastifyStatic (fastify, opts) {
-  opts.root = normalizeRoot(opts.root)
-  checkRootPathForErrors(fastify, opts.root)
+async function fastifyStatic(fastify, opts) {
+  if (opts.serve !== false) {
+    opts.root = normalizeRoot(opts.root)
+    checkRootPathForErrors(fastify, opts.root)
+  }
 
   const setHeaders = opts.setHeaders
   if (setHeaders !== undefined && typeof setHeaders !== 'function') {
@@ -66,7 +68,7 @@ async function fastifyStatic (fastify, opts) {
       hide: opts.schemaHide !== undefined ? opts.schemaHide : true
     },
     logLevel: opts.logLevel,
-    errorHandler (error, request, reply) {
+    errorHandler(error, request, reply) {
       if (error?.code === 'ERR_STREAM_PREMATURE_CLOSE') {
         reply.request.raw.destroy()
         return
@@ -117,7 +119,7 @@ async function fastifyStatic (fastify, opts) {
         ...routeOpts,
         method: ['HEAD', 'GET'],
         path: prefix + '*',
-        handler (req, reply) {
+        handler(req, reply) {
           pumpSendToReply(req, reply, '/' + req.params['*'], sendOptions.root)
         }
       })
@@ -181,7 +183,7 @@ async function fastifyStatic (fastify, opts) {
    * @param {import("@fastify/send").SendOptions} [pumpOptions]
    * @param {Set<string>} [checkedEncodings]
    */
-  async function pumpSendToReply (
+  async function pumpSendToReply(
     request,
     reply,
     pathname,
@@ -299,7 +301,7 @@ async function fastifyStatic (fastify, opts) {
         }
 
         if (metadata.error.code === 'ENOENT') {
-        // when preCompress is enabled and the path is a directory without a trailing slash
+          // when preCompress is enabled and the path is a directory without a trailing slash
           if (opts.preCompressed && encoding) {
             if (opts.redirect !== true) {
               const indexPathname = findIndexFile(pathname, options.root, options.index)
@@ -384,7 +386,7 @@ async function fastifyStatic (fastify, opts) {
     }
   }
 
-  function setUpHeadAndGet (routeOpts, route, file, rootPath) {
+  function setUpHeadAndGet(routeOpts, route, file, rootPath) {
     const toSetUp = Object.assign({}, routeOpts, {
       method: ['HEAD', 'GET'],
       url: route,
@@ -397,7 +399,7 @@ async function fastifyStatic (fastify, opts) {
   }
 
   /** @type {import("fastify").RouteHandlerMethod} */
-  async function serveFileHandler (req, reply) {
+  async function serveFileHandler(req, reply) {
     const routeConfig = req.routeOptions?.config
     return pumpSendToReply(req, reply, routeConfig.file, routeConfig.rootPath)
   }
@@ -407,7 +409,7 @@ async function fastifyStatic (fastify, opts) {
  * @param {import("./types").FastifyStaticOptions['root']} root
  * @returns {import("./types").FastifyStaticOptions['root']}
  */
-function normalizeRoot (root) {
+function normalizeRoot(root) {
   if (root === undefined) {
     return root
   }
@@ -435,7 +437,7 @@ function normalizeRoot (root) {
  * @param {import("./types").FastifyStaticOptions['root']} rootPath
  * @returns {void}
  */
-function checkRootPathForErrors (fastify, rootPath) {
+function checkRootPathForErrors(fastify, rootPath) {
   if (rootPath === undefined) {
     throw new Error('"root" option is required')
   }
@@ -468,7 +470,7 @@ function checkRootPathForErrors (fastify, rootPath) {
  * @param {import("./types").FastifyStaticOptions['root']} rootPath
  * @returns {void}
  */
-function checkPath (fastify, rootPath) {
+function checkPath(fastify, rootPath) {
   if (typeof rootPath !== 'string') {
     throw new TypeError('"root" option must be a string')
   }
@@ -498,7 +500,7 @@ function checkPath (fastify, rootPath) {
  * @param {string} path
  * @return {string}
  */
-function getContentType (path) {
+function getContentType(path) {
   const type = send.mime.getType(path) || send.mime.default_type
 
   if (!send.isUtf8MimeType(type)) {
@@ -513,7 +515,7 @@ function getContentType (path) {
  * @param {import("./types").FastifyStaticOptions['index']} [indexFiles]
  * @return {string|boolean}
  */
-function findIndexFile (pathname, root, indexFiles = ['index.html']) {
+function findIndexFile(pathname, root, indexFiles = ['index.html']) {
   if (Array.isArray(indexFiles)) {
     return indexFiles.find(filename => {
       const p = path.join(root, pathname, filename)
@@ -534,7 +536,7 @@ function findIndexFile (pathname, root, indexFiles = ['index.html']) {
  * @param {import('fastify').FastifyRequest['headers']} headers
  * @param {Set<string>} checked
  */
-function getEncodingHeader (headers, checked) {
+function getEncodingHeader(headers, checked) {
   if (!('accept-encoding' in headers)) return
 
   // consider the no-preference token as gzip for downstream compat
@@ -550,7 +552,7 @@ function getEncodingHeader (headers, checked) {
  * @param {string} encoding
  * @returns {string}
  */
-function getEncodingExtension (encoding) {
+function getEncodingExtension(encoding) {
   switch (encoding) {
     case 'br':
       return 'br'
@@ -564,7 +566,7 @@ function getEncodingExtension (encoding) {
  * @param {string} url
  * @return {string}
  */
-function getRedirectUrl (url) {
+function getRedirectUrl(url) {
   let i = 0
   // we detect how many slash before a valid path
   for (; i < url.length; ++i) {

--- a/test/root/example.html
+++ b/test/root/example.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>test file</title>
+</head>
+<body>
+    <h1>hello fastify</h1>
+</body>
+</html>

--- a/test/serve-option.test.js
+++ b/test/serve-option.test.js
@@ -18,7 +18,7 @@ test('should not serve static files when serve is false', async t => {
   fastify.server.unref()
 
   const res = await fetch('http://localhost:' + fastify.server.address().port + '/public/example.html')
-  assert.strictEqual(res.status, 404);
+  assert.strictEqual(res.status, 404)
 })
 
 test('should serve static files when serve is true', async t => {
@@ -33,8 +33,8 @@ test('should serve static files when serve is true', async t => {
   fastify.server.unref()
 
   const res = await fetch('http://localhost:' + fastify.server.address().port + '/public/example.html')
-  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.status, 200)
 
   const content = await res.text()
-  assert.ok(content.includes('hello'), 'File content should contain "hello"');
+  assert.ok(content.includes('hello'), 'File content should contain "hello"')
 })

--- a/test/serve-option.test.js
+++ b/test/serve-option.test.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const path = require('node:path')
+const assert = require('node:assert')
+const { test } = require('node:test')
+const Fastify = require('fastify')
+const fastifyStatic = require('../index.js')
+
+test('should not serve static files when serve is false', async t => {
+  const fastify = Fastify()
+  fastify.register(fastifyStatic, {
+    serve: false
+  })
+
+  t.after(() => fastify.close())
+  await fastify.listen({ port: 0 })
+  console.log('Server running at http://localhost:0')
+  fastify.server.unref()
+
+  const res = await fetch('http://localhost:' + fastify.server.address().port + '/public/example.html')
+  assert.strictEqual(res.status, 404);
+})
+
+test('should serve static files when serve is true', async t => {
+  const fastify = Fastify()
+  fastify.register(fastifyStatic, {
+    root: path.join(__dirname, 'root'),
+    prefix: '/public/'
+  })
+
+  t.after(() => fastify.close())
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
+
+  const res = await fetch('http://localhost:' + fastify.server.address().port + '/public/example.html')
+  assert.strictEqual(res.status, 200);
+
+  const content = await res.text()
+  assert.ok(content.includes('hello'), 'File content should contain "hello"');
+})

--- a/test/serve-option.test.js
+++ b/test/serve-option.test.js
@@ -14,7 +14,6 @@ test('should not serve static files when serve is false', async t => {
 
   t.after(() => fastify.close())
   await fastify.listen({ port: 0 })
-  console.log('Server running at http://localhost:0')
   fastify.server.unref()
 
   const res = await fetch('http://localhost:' + fastify.server.address().port + '/public/example.html')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -85,7 +85,7 @@ declare namespace fastifyStatic {
   }
 
   export interface FastifyStaticOptions extends SendOptions {
-    root: string | string[] | URL | URL[];
+    root?: string | string[] | URL | URL[];
     prefix?: string;
     prefixAvoidTrailingSlash?: boolean;
     serve?: boolean;


### PR DESCRIPTION
## Summary
This PR makes the `root` option optional when `serve: false` in `fastifyStatic` asynchronous function.
Previously, a dummy directory was required just to satisfy validation.

## Changes
- Updated `index.js` to skip root validation if `serve: false`.
- Added a new test `serve-option.test.js` to verify behavior with and without serving.

## Tests
- `serve: false` → no automatic routes are created, sendFile still works.
- `serve: true` → normal static file serving works as expected.

Fixes #460
