### PR TITLE
fix: if serve: false and root is not defined, only allow sending files with absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,12 @@ fastify.get('/favicon.ico', function (req, reply) {
 
 ### Options
 
-#### `root` (required)
+#### `serve`
+Default: `true`
+
+If set to `false`, the plugin will not serve files from the `root` directory.
+
+#### `root` (required if `serve` is not false)
 
 The absolute path of the directory containing the files to serve.
 The file to serve is determined by combining `req.url` with the

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ send.mime.default_type = 'application/octet-stream'
 
 /** @type {import("fastify").FastifyPluginAsync<import("./types").FastifyStaticOptions>} */
 async function fastifyStatic (fastify, opts) {
-  if (opts.serve !== false) {
+  if (opts.serve !== false || opts.root !== undefined) {
     opts.root = normalizeRoot(opts.root)
     checkRootPathForErrors(fastify, opts.root)
   }

--- a/index.js
+++ b/index.js
@@ -19,8 +19,10 @@ send.mime.default_type = 'application/octet-stream'
 
 /** @type {import("fastify").FastifyPluginAsync<import("./types").FastifyStaticOptions>} */
 async function fastifyStatic (fastify, opts) {
-  opts.root = normalizeRoot(opts.root)
-  checkRootPathForErrors(fastify, opts.root)
+  if (opts.serve !== false) {
+    opts.root = normalizeRoot(opts.root)
+    checkRootPathForErrors(fastify, opts.root)
+  }
 
   const setHeaders = opts.setHeaders
   if (setHeaders !== undefined && typeof setHeaders !== 'function') {
@@ -199,6 +201,8 @@ async function fastifyStatic (fastify, opts) {
       } else {
         options.root = rootPath
       }
+    } else if (path.isAbsolute(pathname) === false) {
+      return reply.callNotFound()
     }
 
     if (allowedPath && !allowedPath(pathname, options.root, request)) {

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1260,7 +1260,7 @@ test('maxAge option', async (t) => {
 })
 
 test('errors', async (t) => {
-  t.plan(11)
+  t.plan(12)
 
   await t.test('no root', async (t) => {
     t.plan(1)
@@ -1321,6 +1321,16 @@ test('errors', async (t) => {
   await t.test('all root array paths must be valid', async (t) => {
     t.plan(1)
     const pluginOptions = { root: [path.join(__dirname, '/static'), 1] }
+    const fastify = Fastify({ logger: false })
+    await t.assert.rejects(async () => await fastify.register(fastifyStatic, pluginOptions))
+  })
+
+  await t.test('no root and serve: false', async (t) => {
+    t.plan(1)
+    const pluginOptions = {
+      serve: false,
+      root: []
+    }
     const fastify = Fastify({ logger: false })
     await t.assert.rejects(async () => await fastify.register(fastifyStatic, pluginOptions))
   })

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -753,6 +753,51 @@ test('serving disabled', async (t) => {
   })
 })
 
+test('serving disabled without root', async (t) => {
+  t.plan(2)
+
+  const pluginOptions = {
+    prefix: '/static/',
+    serve: false
+  }
+  const fastify = Fastify()
+  fastify.register(fastifyStatic, pluginOptions)
+
+  t.after(() => fastify.close())
+
+  fastify.get('/foo/bar/r', (_request, reply) => {
+    reply.sendFile('index.html')
+  })
+
+  fastify.get('/foo/bar/a', (_request, reply) => {
+    reply.sendFile(path.join(__dirname, pluginOptions.prefix, 'index.html'))
+  })
+
+  t.after(() => fastify.close())
+
+  await fastify.listen({ port: 0 })
+
+  fastify.server.unref()
+
+  await t.test('/static/index.html via sendFile not found', async (t) => {
+    t.plan(3 + GENERIC_RESPONSE_CHECK_COUNT)
+
+    const response = await fetch('http://localhost:' + fastify.server.address().port + '/foo/bar/a')
+    t.assert.ok(response.ok)
+    t.assert.deepStrictEqual(response.status, 200)
+    t.assert.deepStrictEqual(await response.text(), indexContent)
+    genericResponseChecks(t, response)
+  })
+
+  await t.test('/static/index.html via sendFile with relative path not found', async (t) => {
+    t.plan(2)
+
+    const response = await fetch('http://localhost:' + fastify.server.address().port + '/foo/bar/r')
+    t.assert.ok(!response.ok)
+    t.assert.deepStrictEqual(response.status, 404)
+  })
+})
+
 test('sendFile', async (t) => {
   t.plan(4)
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -84,17 +84,19 @@ declare namespace fastifyStatic {
     serveDotFiles?: boolean;
   }
 
-  type Root = {
+  type Root = string | string[] | URL | URL[]
+
+  type RootOptions = {
     serve: true;
-    root: string | string[] | URL | URL[];
+    root: Root;
   } | {
     serve?: false;
-    root?: string | string[] | URL | URL[];
+    root?: Root;
   }
 
   export type FastifyStaticOptions =
     SendOptions
-    & Root
+    & RootOptions
     & {
       // Added by this plugin
       prefix?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -84,39 +84,49 @@ declare namespace fastifyStatic {
     serveDotFiles?: boolean;
   }
 
-  export interface FastifyStaticOptions extends SendOptions {
+  type Root = {
+    serve: true;
     root: string | string[] | URL | URL[];
-    prefix?: string;
-    prefixAvoidTrailingSlash?: boolean;
-    serve?: boolean;
-    decorateReply?: boolean;
-    schemaHide?: boolean;
-    setHeaders?: (res: SetHeadersResponse, path: string, stat: Stats) => void;
-    redirect?: boolean;
-    wildcard?: boolean;
-    globIgnore?: string[];
-    list?: boolean | ListOptionsJsonFormat | ListOptionsHtmlFormat;
-    allowedPath?: (pathName: string, root: string, request: FastifyRequest) => boolean;
-    /**
-     * @description
-     * Opt-in to looking for pre-compressed files
-     */
-    preCompressed?: boolean;
-
-    // Passed on to `send`
-    acceptRanges?: boolean;
-    contentType?: boolean;
-    cacheControl?: boolean;
-    dotfiles?: 'allow' | 'deny' | 'ignore';
-    etag?: boolean;
-    extensions?: string[];
-    immutable?: boolean;
-    index?: string[] | string | false;
-    lastModified?: boolean;
-    maxAge?: string | number;
-    constraints?: RouteOptions['constraints'];
-    logLevel?: RouteOptions['logLevel'];
+  } | {
+    serve?: false;
+    root?: string | string[] | URL | URL[];
   }
+
+  export type FastifyStaticOptions =
+    SendOptions
+    & Root
+    & {
+      // Added by this plugin
+      prefix?: string;
+      prefixAvoidTrailingSlash?: boolean;
+      decorateReply?: boolean;
+      schemaHide?: boolean;
+      setHeaders?: (res: SetHeadersResponse, path: string, stat: Stats) => void;
+      redirect?: boolean;
+      wildcard?: boolean;
+      globIgnore?: string[];
+      list?: boolean | ListOptionsJsonFormat | ListOptionsHtmlFormat;
+      allowedPath?: (pathName: string, root: string, request: FastifyRequest) => boolean;
+      /**
+       * @description
+       * Opt-in to looking for pre-compressed files
+       */
+      preCompressed?: boolean;
+
+      // Passed on to `send`
+      acceptRanges?: boolean;
+      contentType?: boolean;
+      cacheControl?: boolean;
+      dotfiles?: 'allow' | 'deny' | 'ignore';
+      etag?: boolean;
+      extensions?: string[];
+      immutable?: boolean;
+      index?: string[] | string | false;
+      lastModified?: boolean;
+      maxAge?: string | number;
+      constraints?: RouteOptions['constraints'];
+      logLevel?: RouteOptions['logLevel'];
+    }
 
   export const fastifyStatic: FastifyStaticPlugin
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -120,6 +120,19 @@ expectAssignable<FastifyStaticOptions>({
   root: [new URL('')]
 })
 
+expectError<FastifyStaticOptions>({
+  serve: true
+})
+
+expectAssignable<FastifyStaticOptions>({
+  serve: true,
+  root: ''
+})
+
+expectAssignable<FastifyStaticOptions>({
+  serve: false
+})
+
 appWithImplicitHttp
   .register(fastifyStatic, options)
   .after(() => {


### PR DESCRIPTION
If serve is set to false, it only allows to send files specified with an absolute path. Or else sendFile makes no sense anymore, despite that we want to allow the use of sendFile.



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
