### PR TITLE
feat: use node's built-in globbing tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,7 @@
     "@fastify/send": "^4.0.0",
     "content-disposition": "^1.0.1",
     "fastify-plugin": "^5.0.0",
-    "fastq": "^1.17.1",
-    "glob": "^11.0.0"
+    "fastq": "^1.17.1"
   },
   "devDependencies": {
     "@fastify/compress": "^8.0.0",

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -2437,13 +2437,18 @@ test('if dotfiles are properly served according to plugin options', async (t) =>
 
 test('register with failing glob handler', async (t) => {
   const fastifyStatic = proxyquire.noCallThru()('../', {
-    glob: function globStub (_pattern, _options, cb) {
-      process.nextTick(function () {
-        return cb(new Error('mock glob error'))
-      })
+    'node:fs/promises': {
+      glob: function globStub (_pattern, _options) {
+        return {
+          [Symbol.asyncIterator] () {
+            return {
+              next: async () => { throw new Error('mock glob error') }
+            }
+          }
+        }
+      }
     }
   })
-
   const pluginOptions = {
     root: path.join(__dirname, '/static'),
     serve: true,


### PR DESCRIPTION
We CANNOT move to node's built-in globbing mechanism, this PR is to show this, and can potentially be used later to build upon.
The `node:fs.glob` function does not traverse symbolic links that point to directories. It does not expose an option to enable traversal of directory symlinks, unlike the behavior found in the existing globbing libraries.

I have raised a feature request with the node team for this: https://github.com/nodejs/node/issues/61033
Relevant node globbing file: https://github.com/nodejs/node/blob/main/lib/internal/fs/glob.js

Failing tests:
```
✖ should follow symbolic link without wildcard (12.977115ms)
✖ should serve files into hidden dir with wildcard `false` (7.238363ms)
```

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
