### PR TITLE
test: move ignoreTrailingSlash under routerOptions

### DIFF
--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1712,7 +1712,9 @@ test('register with wildcard false (trailing slash in the root)', async t => {
     wildcard: false
   }
   const fastify = Fastify({
-    ignoreTrailingSlash: true
+    routerOptions: {
+      ignoreTrailingSlash: true
+    }
   })
   fastify.register(fastifyStatic, pluginOptions)
 


### PR DESCRIPTION
While working on an issue in this repository, I ran the test suite and hit the following warning:

```
[FSTDEP022] FastifyWarning: The router options for ignoreTrailingSlash property access is deprecated.
Please use "options.routerOptions" instead. This will be removed in fastify@6.
```

This PR updates the code accordingly and removes the warning.


#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
