### PR TITLE
issue: Add the example code using ESM #544

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,26 @@ See [Fastify's LTS policy](https://github.com/fastify/fastify/blob/main/docs/Ref
 ## Usage
 
 ```js
-const fastify = require('fastify')({logger: true})
-const path = require('node:path')
+// ESM
+import path from "path";
+import Fastify from "fastify";
+const fastify = Fastify({ logger: true });
 
-fastify.register(require('@fastify/static'), {
-  root: path.join(__dirname, 'public'),
-  prefix: '/public/', // optional: default '/'
-  constraints: { host: 'example.com' } // optional: default {}
-})
+fastify.register(import("@fastify/static"), {
+  root: path.join(__dirname, "public"),
+  prefix: "/public/", // optional: default '/'
+  constraints: { host: "example.com" }, // optional: default {}
+});
+
+// CommonJs
+const fastify = require("fastify")({ logger: true });
+const path = require("node:path");
+
+fastify.register(require("@fastify/static"), {
+  root: path.join(__dirname, "public"),
+  prefix: "/public/", // optional: default '/'
+  constraints: { host: "example.com" }, // optional: default {}
+});
 
 fastify.get('/another/path', function (req, reply) {
   reply.sendFile('myHtml.html') // serving path.join(__dirname, 'public', 'myHtml.html') directly


### PR DESCRIPTION
README.md updated.
Tests for plugin ES modules exist already on fastify's  repository at /test/esm.

Please confirm or reject.
Thank you

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
