### PR TITLE
chore: update syntax typescript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,3 @@
-// Definitions by: Jannik <https://github.com/jannikkeye>
-//                 Leo <https://github.com/leomelzer>
-/// <reference types="node" />
-
 import { FastifyPluginAsync, FastifyReply, FastifyRequest, RouteOptions } from 'fastify'
 import { Stats } from 'node:fs'
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -8,7 +8,7 @@ import fastifyStatic, {
   fastifyStatic as fastifyStaticNamed
 } from '..'
 
-import fastifyStaticCjsImport = require('..')
+const fastifyStaticCjsImport = fastifyStaticStar
 const fastifyStaticCjs = require('..')
 
 const app: FastifyInstance = fastify()


### PR DESCRIPTION
Proposals:

- Remove triple-slash reference directive from `index.d.ts`, as this syntax will be removed in future TypeScript version
- Remove outdated author credits from `index.d.ts`
- Replace CJS `import = require()` with const assignment in `index.test-d.ts` ( see screenshot )

<img width="1658" height="130" alt="screenshot-error-syntax" src="https://github.com/user-attachments/assets/9173308d-2788-46fb-9fcf-9f2753cfb7e4" />
