### PR TITLE
fix: sendFile ignoring option overrides in some cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,7 +274,7 @@ async function fastifyStatic (fastify, opts) {
               pathname + '/',
               rootPath,
               undefined,
-              undefined,
+              pumpOptions,
               checkedEncodings
             )
           }
@@ -314,7 +314,7 @@ async function fastifyStatic (fastify, opts) {
                   pathname + '/',
                   rootPath,
                   undefined,
-                  undefined,
+                  pumpOptions,
                   checkedEncodings
                 )
               }
@@ -336,7 +336,15 @@ async function fastifyStatic (fastify, opts) {
 
           // root paths left to try?
           if (Array.isArray(rootPath) && rootPathOffset < (rootPath.length - 1)) {
-            return pumpSendToReply(request, reply, pathname, rootPath, rootPathOffset + 1)
+            return pumpSendToReply(
+              request,
+              reply,
+              pathname,
+              rootPath,
+              rootPathOffset + 1,
+              pumpOptions,
+              undefined
+            )
           }
 
           if (opts.preCompressed && !checkedEncodings.has(encoding)) {
@@ -347,7 +355,7 @@ async function fastifyStatic (fastify, opts) {
               pathnameOrig,
               rootPath,
               rootPathOffset,
-              undefined,
+              pumpOptions,
               checkedEncodings
             )
           }

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -870,6 +870,83 @@ test('sendFile', async (t) => {
   })
 })
 
+test('sendFile with multiple roots', async (t) => {
+  t.plan(4)
+
+  const pluginOptions = {
+    root: [path.join(__dirname, '/static'), path.join(__dirname, '/static2')],
+    prefix: '/static'
+  }
+  const fastify = Fastify()
+  const maxAge = Math.round(Math.random() * 10) * 10000
+  fastify.register(fastifyStatic, pluginOptions)
+
+  t.after(() => fastify.close())
+
+  fastify.get('/foo', function (_req, rep) {
+    rep.sendFile('foo.html')
+  })
+
+  fastify.get('/foo-with-options', function (_req, rep) {
+    rep.sendFile('foo.html', { maxAge })
+  })
+
+  fastify.get('/bar', function (_req, rep) {
+    rep.sendFile('bar.html')
+  })
+
+  fastify.get('/bar-with-options', function (_req, rep) {
+    rep.sendFile('bar.html', { maxAge })
+  })
+
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
+
+  await t.test('reply.sendFile() first root', async (t) => {
+    t.plan(4 + GENERIC_RESPONSE_CHECK_COUNT)
+
+    const response = await fetch('http://localhost:' + fastify.server.address().port + '/foo')
+    t.assert.ok(response.ok)
+    t.assert.deepStrictEqual(response.status, 200)
+    t.assert.deepStrictEqual(await response.text(), fooContent)
+    t.assert.deepStrictEqual(response.headers.get('cache-control'), 'public, max-age=0')
+    genericResponseChecks(t, response)
+  })
+
+  await t.test('reply.sendFile() first root with options', async (t) => {
+    t.plan(4 + GENERIC_RESPONSE_CHECK_COUNT)
+
+    const response = await fetch('http://localhost:' + fastify.server.address().port + '/foo-with-options')
+    t.assert.ok(response.ok)
+    t.assert.deepStrictEqual(response.status, 200)
+    t.assert.deepStrictEqual(await response.text(), fooContent)
+    t.assert.deepStrictEqual(response.headers.get('cache-control'), `public, max-age=${maxAge / 1000}`)
+    genericResponseChecks(t, response)
+  })
+
+  await t.test('reply.sendFile() second root', async (t) => {
+    t.plan(4 + GENERIC_RESPONSE_CHECK_COUNT)
+
+    const response = await fetch('http://localhost:' + fastify.server.address().port + '/bar')
+    t.assert.ok(response.ok)
+    t.assert.deepStrictEqual(response.status, 200)
+    t.assert.deepStrictEqual(await response.text(), barContent)
+    t.assert.deepStrictEqual(response.headers.get('cache-control'), 'public, max-age=0')
+    genericResponseChecks(t, response)
+  })
+
+  await t.test('reply.sendFile() second root with options', async (t) => {
+    t.plan(4 + GENERIC_RESPONSE_CHECK_COUNT)
+
+    const response = await fetch('http://localhost:' + fastify.server.address().port + '/bar-with-options')
+    t.assert.ok(response.ok)
+    t.assert.deepStrictEqual(response.status, 200)
+    t.assert.deepStrictEqual(await response.text(), barContent)
+    t.assert.deepStrictEqual(response.headers.get('cache-control'), `public, max-age=${maxAge / 1000}`)
+    genericResponseChecks(t, response)
+  })
+})
+
 test('sendFile disabled', async (t) => {
   t.plan(1)
 


### PR DESCRIPTION
This fixes a bug where `options` passed to `sendFile()`/`download()` are ignored in some cases, due to `pumpSendToReply()` not passing the options when calling itself recursively.

The specific case I ran into involved multiple roots. `pumpSendToReply()` uses recursion to iterate through all the roots, but was not passing `pumpOptions` to recursive calls. I've added a test for this case.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
