### PR TITLE
chore: upgrade c8 to v11.0.0 and improvements test

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@fastify/compress": "^8.0.0",
     "@types/node": "^25.0.3",
     "borp": "^1.0.0",
-    "c8": "^10.1.3",
+    "c8": "^11.0.0",
     "concat-stream": "^2.0.0",
     "eslint": "^9.17.0",
     "fastify": "^5.1.0",

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1438,7 +1438,7 @@ test('register no prefix', async (t) => {
   })
 })
 
-test('with fastify-compress', { timeout: 60000 }, async t => {
+test('with fastify-compress', async t => {
   t.plan(2)
 
   const pluginOptions = {
@@ -1451,8 +1451,6 @@ test('with fastify-compress', { timeout: 60000 }, async t => {
   t.after(() => fastify.close())
 
   await fastify.listen({ port: 0 })
-
-  fastify.server.unref()
 
   await t.test('deflate', async function (t) {
     t.plan(3 + GENERIC_RESPONSE_CHECK_COUNT)
@@ -1478,6 +1476,7 @@ test('with fastify-compress', { timeout: 60000 }, async t => {
     genericResponseChecks(t, response)
   })
 })
+
 test('register /static/ with schemaHide true', async t => {
   t.plan(2)
 

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1439,6 +1439,8 @@ test('register no prefix', async (t) => {
 })
 
 test('with fastify-compress', { timeout: 60000 }, async t => {
+  t.plan(2)
+
   const pluginOptions = {
     root: path.join(__dirname, '/static')
   }

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1439,8 +1439,6 @@ test('register no prefix', async (t) => {
 })
 
 test('with fastify-compress', { timeout: 60000 }, async t => {
-  t.plan(2)
-
   const pluginOptions = {
     root: path.join(__dirname, '/static')
   }

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1439,7 +1439,7 @@ test('register no prefix', async (t) => {
 })
 
 test('with fastify-compress', async t => {
-  t.plan(2)
+  // t.plan(2)
 
   const pluginOptions = {
     root: path.join(__dirname, '/static')

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1438,7 +1438,7 @@ test('register no prefix', async (t) => {
   })
 })
 
-test('with fastify-compress', async t => {
+test('with fastify-compress', { timeout: 60000 }, async t => {
   t.plan(2)
 
   const pluginOptions = {

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1438,9 +1438,7 @@ test('register no prefix', async (t) => {
   })
 })
 
-test('with fastify-compress', async t => {
-  // t.plan(2)
-
+test('with fastify-compress', { timeout: 60000 }, async t => {
   const pluginOptions = {
     root: path.join(__dirname, '/static')
   }


### PR DESCRIPTION
Proposals:

- Upgrade `c8` to `v11.0.0`
- Improvements the `with fastify-compress` test was timing out on CI (GitHub Actions) after 30000ms, while passing locally. 

This PR should resolve this PR https://github.com/fastify/fastify-static/pull/561
