### PR TITLE
Refactor/use node fs glob

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 const path = require('node:path')
 const { fileURLToPath } = require('node:url')
-const { statSync } = require('node:fs')
-const { glob } = require('glob')
+const { statSync, lstatSync, realpathSync } = require('node:fs')
+const { glob } = require('node:fs/promises')
 const fp = require('fastify-plugin')
 const send = require('@fastify/send')
 const encodingNegotiator = require('@fastify/accept-negotiator')
@@ -63,7 +63,6 @@ async function fastifyStatic (fastify, opts) {
         : prefix + '/'
   }
 
-  // Set the schema hide property if defined in opts or true by default
   const routeOpts = {
     constraints: opts.constraints,
     schema: {
@@ -139,25 +138,55 @@ async function fastifyStatic (fastify, opts) {
       for (let rootPath of roots) {
         rootPath = rootPath.split(path.win32.sep).join(path.posix.sep)
         !rootPath.endsWith('/') && (rootPath += '/')
-        const files = await glob('**/**', {
-          cwd: rootPath, absolute: false, follow: true, nodir: true, dot: opts.serveDotFiles, ignore: opts.globIgnore
-        })
 
-        for (let file of files) {
-          file = file.split(path.win32.sep).join(path.posix.sep)
-          const route = prefix + file
+        const globPattern = opts.serveDotFiles ? '{**/**,.**/**}' : '**/**'
+        const globExclude = opts.globIgnore?.length
+          ? (f) => opts.globIgnore.some(p => path.matchesGlob(f, p))
+          : undefined
 
-          if (routes.has(route)) {
-            continue
-          }
+        const scanQueue = [{ cwd: rootPath.slice(0, -1), relPrefix: '' }]
+        const visitedDirs = new Set([realpathSync(rootPath.slice(0, -1))])
 
-          routes.add(route)
+        const toUnixPath = (p) => p.split(path.win32.sep).join(path.posix.sep)
+        const tryFsSync = (fn, p) => { try { return fn(p) } catch { return null } }
 
-          setUpHeadAndGet(routeOpts, route, `/${file}`, rootPath)
+        while (scanQueue.length > 0) {
+          const { cwd: scanCwd, relPrefix } = scanQueue.shift()
+          for await (const f of glob(globPattern, { cwd: scanCwd, exclude: globExclude })) {
+            if (f === '.') continue
 
-          const key = path.posix.basename(route)
-          if (indexes.has(key) && !indexDirs.has(key)) {
-            indexDirs.set(path.posix.dirname(route), rootPath)
+            const file = toUnixPath(f)
+            const fullPath = path.join(scanCwd, file)
+            const lstat = tryFsSync(lstatSync, fullPath)
+            if (!lstat || lstat.isDirectory()) continue
+
+            const relFile = relPrefix ? `${relPrefix}/${file}` : file
+
+            if (lstat.isSymbolicLink()) {
+              const stat = tryFsSync(statSync, fullPath)
+              if (!stat) continue
+
+              if (stat.isDirectory()) {
+                const realPath = tryFsSync(realpathSync, fullPath)
+                /* c8 ignore next */
+                if (!realPath) continue
+                if (!visitedDirs.has(realPath)) {
+                  visitedDirs.add(realPath)
+                  scanQueue.push({ cwd: fullPath, relPrefix: relFile })
+                }
+                continue
+              }
+            }
+
+            const route = prefix + relFile
+            if (routes.has(route)) continue
+            routes.add(route)
+            setUpHeadAndGet(routeOpts, route, `/${relFile}`, rootPath)
+
+            const key = path.posix.basename(route)
+            if (indexes.has(key) && !indexDirs.has(key)) {
+              indexDirs.set(path.posix.dirname(route), rootPath)
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/static",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Plugin for serving static files as fast as possible.",
   "main": "index.js",
   "type": "commonjs",
@@ -58,23 +58,22 @@
     }
   ],
   "dependencies": {
-    "@fastify/accept-negotiator": "^2.0.0",
-    "@fastify/send": "^4.0.0",
+    "@fastify/accept-negotiator": "^2.0.1",
+    "@fastify/send": "^4.1.0",
     "content-disposition": "^1.0.1",
-    "fastify-plugin": "^5.0.0",
-    "fastq": "^1.17.1",
-    "glob": "^13.0.0"
+    "fastify-plugin": "^5.1.0",
+    "fastq": "^1.17.1"
   },
   "devDependencies": {
-    "@fastify/compress": "^8.0.0",
+    "@fastify/compress": "^8.3.1",
     "@types/node": "^25.0.3",
     "borp": "^1.0.0",
     "c8": "^11.0.0",
     "concat-stream": "^2.0.0",
     "eslint": "^9.17.0",
-    "fastify": "^5.1.0",
+    "fastify": "^5.8.4",
     "neostandard": "^0.12.0",
-    "pino": "^10.0.0",
+    "pino": "^10.3.1",
     "proxyquire": "^2.1.3",
     "tsd": "^0.33.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/static",
-  "version": "9.1.1",
+  "version": "9.1.0",
   "description": "Plugin for serving static files as fast as possible.",
   "main": "index.js",
   "type": "commonjs",

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -3906,3 +3906,78 @@ test('register with wildcard false and globIgnore', async t => {
     await response.text()
   })
 })
+
+test('should serve file from a symlinked directory', async (t) => {
+  t.plan(1)
+
+  const tempDir = fs.mkdtempSync(path.join(__dirname, 'symlink-test-'))
+  const realDir = path.join(tempDir, 'real')
+  const symlinkedDir = path.join(tempDir, 'symlinked')
+  const testFilePath = path.join(realDir, 'test.txt')
+  const fileContent = 'symlink test file'
+
+  fs.mkdirSync(realDir)
+  fs.writeFileSync(testFilePath, fileContent)
+  fs.symlinkSync(realDir, symlinkedDir, 'dir')
+
+  const fastify = Fastify()
+  fastify.register(fastifyStatic, {
+    root: tempDir,
+    prefix: '/',
+    followSymlinks: true
+  })
+
+  t.after(async () => {
+    await fastify.close()
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
+
+  await t.test('request file via symlink', async (t) => {
+    t.plan(3)
+    const response = await fetch(`http://localhost:${fastify.server.address().port}/symlinked/test.txt`)
+    t.assert.ok(response.ok)
+    t.assert.deepStrictEqual(response.status, 200)
+    t.assert.deepStrictEqual(await response.text(), fileContent)
+  })
+})
+
+test('should serve file with user-defined wildcard route', async (t) => {
+  t.plan(1)
+
+  const tempDir = fs.mkdtempSync(path.join(__dirname, 'wildcard-sendFile-test-'))
+  const testFilePath = path.join(tempDir, 'foo', 'bar.txt')
+  const fileContent = 'wildcard sendFile test'
+
+  fs.mkdirSync(path.dirname(testFilePath), { recursive: true })
+  fs.writeFileSync(testFilePath, fileContent)
+
+  const fastify = Fastify()
+  // The root needs to be specified for reply.sendFile to resolve relative paths
+  fastify.register(fastifyStatic, {
+    root: tempDir,
+    serve: false // We don't want the plugin to serve files, just decorate reply.sendFile
+  })
+
+  fastify.get('/files/*', (req, reply) => {
+    reply.sendFile(req.params['*'])
+  })
+
+  t.after(async () => {
+    await fastify.close()
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
+
+  await t.test('request file via wildcard route', async (t) => {
+    t.plan(3)
+    const response = await fetch(`http://localhost:${fastify.server.address().port}/files/foo/bar.txt`)
+    t.assert.ok(response.ok)
+    t.assert.deepStrictEqual(response.status, 200)
+    t.assert.deepStrictEqual(await response.text(), fileContent)
+  })
+})

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -2517,10 +2517,8 @@ test('if dotfiles are properly served according to plugin options', async (t) =>
 
 test('register with failing glob handler', async (t) => {
   const fastifyStatic = proxyquire.noCallThru()('../', {
-    glob: function globStub (_pattern, _options, cb) {
-      process.nextTick(function () {
-        return cb(new Error('mock glob error'))
-      })
+    'node:fs/promises': {
+      glob: async function * globStub () { throw new Error('mock glob error') }
     }
   })
 
@@ -3351,6 +3349,43 @@ test('should follow symbolic link without wildcard', async (t) => {
   const response2 = await fetch('http://localhost:' + fastify.server.address().port + '/dir/symlink/subdir/subdir/index.html')
   t.assert.ok(response2.ok)
   t.assert.deepStrictEqual(response2.status, 200)
+})
+
+test('should not infinite-loop on circular symlinks with wildcard false', async (t) => {
+  const base = path.join(__dirname, '/static-symbolic-link')
+  const dirA = path.join(base, 'circular-a')
+  const linkB = path.join(base, 'circular-b')
+  // clean up any leftovers from a previous failed run
+  try { fs.unlinkSync(path.join(dirA, 'link-to-b')) } catch { /* not there */ }
+  try { fs.unlinkSync(linkB) } catch { /* not there */ }
+  fs.rmSync(dirA, { recursive: true, force: true })
+  fs.mkdirSync(dirA)
+  fs.symlinkSync(path.join(dirA, 'link-to-b'), linkB, 'dir')   // circular-b → circular-a/link-to-b
+  fs.symlinkSync(linkB, path.join(dirA, 'link-to-b'), 'dir')   // circular-a/link-to-b → circular-b
+
+  t.after(() => {
+    try { fs.unlinkSync(path.join(dirA, 'link-to-b')) } catch { /* already gone */ }
+    try { fs.unlinkSync(linkB) } catch { /* already gone */ }
+    try { fs.rmdirSync(dirA) } catch { /* already gone */ }
+  })
+
+  const fastify = Fastify()
+  fastify.register(fastifyStatic, {
+    root: base,
+    wildcard: false
+  })
+  t.after(() => fastify.close())
+
+  // fastify.listen must complete (not hang/crash) — that is the assertion
+  await fastify.listen({ port: 0 })
+  fastify.server.unref()
+
+  // Original non-circular files still served correctly
+  const response = await fetch(
+    'http://localhost:' + fastify.server.address().port + '/origin/subdir/subdir/index.html'
+  )
+  t.assert.ok(response.ok)
+  t.assert.deepStrictEqual(response.status, 200)
 })
 
 test('should serve files into hidden dir with wildcard `false`', async (t) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR resolves issue #551 by replacing the external `glob` dependency with the native `glob` utility provided by `node:fs/promises`.

**Key Implementation Details:**
-------------------------------

- **Dependency Removal:** Completely removed the external `glob` package, reducing the dependency tree.
- **Native Globbing:** Implemented `for await...of glob(...)` to asynchronously scan directories  when `wildcard: false` is used.
- **Symlink Support:** Since the native Node.js `glob` does not follow directory symbolic links by default, a custom recursive `scanQueue` and `visitedDirs` mechanism was added to preserve existing symlink behavior and prevent infinite loops on circular symlinks.
- **Filtering:** Adopted the native `path.matchesGlob` to handle the `globIgnore` filtering logic.
- **Note on Node.js Compatibility:**

Because this implementation utilizes `path.matchesGlob`, it relies on APIs introduced in Node.js **v22.0.0** (and `glob` from `node:fs/promises` available in v22.0.0 / v20.15.0).

[![Open Source Saturday Turin](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-Open%20Source%20Saturday%20Turin-F64060.svg)](https://lu.ma/open-source-saturday-torino)

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
