### PR TITLE
fix: support wildcard prefixes with route params

### DIFF
--- a/example/server-benchmark.js
+++ b/example/server-benchmark.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const path = require('node:path')
+const fastify = require('fastify')({ logger: false })
+const fastifyStatic = require(process.env.PLUGIN_PATH || '../')
+
+const root = path.join(__dirname, '/public')
+const port = Number(process.env.PORT || 3000)
+
+fastify.register(fastifyStatic, {
+  root,
+  prefix: '/static',
+  decorateReply: false
+})
+
+fastify.register(fastifyStatic, {
+  root,
+  prefix: '/app/:version',
+  decorateReply: false
+})
+
+fastify.register(async function (child) {
+  child.register(fastifyStatic, {
+    root,
+    prefix: '/public',
+    decorateReply: false
+  })
+}, { prefix: '/nested' })
+
+fastify.listen({ port }, err => {
+  if (err) throw err
+
+  console.log(`benchmark server listening on http://127.0.0.1:${port}`)
+  console.log('')
+  console.log('Try:')
+  console.log(`  npx autocannon -c 100 -d 10 http://127.0.0.1:${port}/static/index.css`)
+  console.log(`  npx autocannon -c 100 -d 10 http://127.0.0.1:${port}/app/1.2.3/index.css`)
+  console.log(`  npx autocannon -c 100 -d 10 http://127.0.0.1:${port}/nested/public/index.css`)
+})

--- a/index.js
+++ b/index.js
@@ -609,10 +609,11 @@ function createRoutePrefixTokens (routePrefix) {
 
 /**
  * @param {string} pathname
+ * @param {number} pathnameEnd
  * @param {Array<string|undefined>} tokens
  * @returns {number|undefined}
  */
-function getRoutePrefixMatchLength (pathname, tokens) {
+function getRoutePrefixMatchLength (pathname, pathnameEnd, tokens) {
   let pathnameIndex = 0
 
   for (const token of tokens) {
@@ -620,8 +621,8 @@ function getRoutePrefixMatchLength (pathname, tokens) {
       const segmentStart = pathnameIndex
       const slashIndex = pathname.indexOf('/', pathnameIndex)
 
-      pathnameIndex = slashIndex === -1
-        ? pathname.length
+      pathnameIndex = slashIndex === -1 || slashIndex > pathnameEnd
+        ? pathnameEnd
         : slashIndex
 
       if (pathnameIndex === segmentStart) {
@@ -631,11 +632,12 @@ function getRoutePrefixMatchLength (pathname, tokens) {
       continue
     }
 
-    if (!pathname.startsWith(token, pathnameIndex)) {
+    const tokenEnd = pathnameIndex + token.length
+    if (tokenEnd > pathnameEnd || !pathname.startsWith(token, pathnameIndex)) {
       return
     }
 
-    pathnameIndex += token.length
+    pathnameIndex = tokenEnd
   }
 
   return pathnameIndex
@@ -643,40 +645,41 @@ function getRoutePrefixMatchLength (pathname, tokens) {
 
 /**
  * @param {string} route
- * @returns {(pathname: string) => number|undefined}
+ * @returns {(pathname: string, pathnameEnd: number) => number|undefined}
  */
 function createRoutePrefixMatcher (route) {
   const routePrefix = route.replace(/\*$/u, '')
+  const routePrefixLength = routePrefix.length
 
   if (routePrefix === '/') {
     return () => 0
   }
 
   if (routePrefix.includes(':') === false) {
-    return (pathname) => pathname.startsWith(routePrefix)
-      ? routePrefix.length
+    return (pathname, pathnameEnd) => routePrefixLength <= pathnameEnd && pathname.startsWith(routePrefix)
+      ? routePrefixLength
       : undefined
   }
 
   const tokens = createRoutePrefixTokens(routePrefix)
-  return (pathname) => getRoutePrefixMatchLength(pathname, tokens)
+  return (pathname, pathnameEnd) => getRoutePrefixMatchLength(pathname, pathnameEnd, tokens)
 }
 
 /**
  * @param {string} url
- * @param {(pathname: string) => number|undefined} matchRoutePrefix
+ * @param {(pathname: string, pathnameEnd: number) => number|undefined} matchRoutePrefix
  * @returns {string|undefined}
  */
 function getPathnameForSend (url, matchRoutePrefix) {
   const questionMark = url.indexOf('?')
-  let pathname = questionMark === -1 ? url : url.slice(0, questionMark)
+  const pathnameEnd = questionMark === -1 ? url.length : questionMark
 
-  const prefixLength = matchRoutePrefix(pathname)
+  const prefixLength = matchRoutePrefix(url, pathnameEnd)
   if (prefixLength === undefined) {
     return
   }
 
-  pathname = pathname.slice(prefixLength)
+  let pathname = url.slice(prefixLength, pathnameEnd)
 
   if (pathname === '') {
     pathname = '/'

--- a/index.js
+++ b/index.js
@@ -623,9 +623,7 @@ function getPathnameForSend (url, route) {
   const questionMark = url.indexOf('?')
   let pathname = questionMark === -1 ? url : url.slice(0, questionMark)
 
-  const routePrefix = route.endsWith('*')
-    ? route.slice(0, -1)
-    : route
+  const routePrefix = route.replace(/\*$/u, '')
 
   const prefixLength = getRoutePrefixMatchLength(pathname, routePrefix)
   if (prefixLength === undefined) {

--- a/index.js
+++ b/index.js
@@ -117,12 +117,16 @@ async function fastifyStatic (fastify, opts) {
       throw new TypeError('"wildcard" option must be a boolean')
     }
     if (opts.wildcard === undefined || opts.wildcard === true) {
+      let matchRoutePrefix
+
       fastify.route({
         ...routeOpts,
         method: ['HEAD', 'GET'],
         path: prefix + '*',
         handler (req, reply) {
-          const pathname = getPathnameForSend(req.raw.url, req.routeOptions.url)
+          matchRoutePrefix ??= createRoutePrefixMatcher(req.routeOptions.url)
+
+          const pathname = getPathnameForSend(req.raw.url, matchRoutePrefix)
           if (!pathname) {
             return reply.callNotFound()
           }
@@ -569,32 +573,56 @@ function getEncodingHeader (headers, checked) {
 }
 
 /**
- * @param {string} pathname
  * @param {string} routePrefix
- * @returns {number|undefined}
+ * @returns {Array<string|undefined>}
  */
-function getRoutePrefixMatchLength (pathname, routePrefix) {
-  if (routePrefix === '/') {
-    return 0
-  }
-
-  let pathnameIndex = 0
+function createRoutePrefixTokens (routePrefix) {
+  const tokens = []
   let routeIndex = 0
+  let segmentStart = 0
 
   while (routeIndex < routePrefix.length) {
-    const routeChar = routePrefix[routeIndex]
-
-    if (routeChar === ':') {
+    if (routePrefix[routeIndex] !== ':') {
       routeIndex++
+      continue
+    }
 
-      while (routeIndex < routePrefix.length && routePrefix[routeIndex] !== '/') {
-        routeIndex++
-      }
+    if (segmentStart !== routeIndex) {
+      tokens.push(routePrefix.slice(segmentStart, routeIndex))
+    }
 
+    routeIndex++
+    while (routeIndex < routePrefix.length && routePrefix[routeIndex] !== '/') {
+      routeIndex++
+    }
+
+    tokens.push(undefined)
+    segmentStart = routeIndex
+  }
+
+  if (segmentStart !== routePrefix.length) {
+    tokens.push(routePrefix.slice(segmentStart))
+  }
+
+  return tokens
+}
+
+/**
+ * @param {string} pathname
+ * @param {Array<string|undefined>} tokens
+ * @returns {number|undefined}
+ */
+function getRoutePrefixMatchLength (pathname, tokens) {
+  let pathnameIndex = 0
+
+  for (const token of tokens) {
+    if (token === undefined) {
       const segmentStart = pathnameIndex
-      while (pathnameIndex < pathname.length && pathname[pathnameIndex] !== '/') {
-        pathnameIndex++
-      }
+      const slashIndex = pathname.indexOf('/', pathnameIndex)
+
+      pathnameIndex = slashIndex === -1
+        ? pathname.length
+        : slashIndex
 
       if (pathnameIndex === segmentStart) {
         return
@@ -603,29 +631,47 @@ function getRoutePrefixMatchLength (pathname, routePrefix) {
       continue
     }
 
-    if (pathnameIndex >= pathname.length || pathname[pathnameIndex] !== routeChar) {
+    if (!pathname.startsWith(token, pathnameIndex)) {
       return
     }
 
-    pathnameIndex++
-    routeIndex++
+    pathnameIndex += token.length
   }
 
   return pathnameIndex
 }
 
 /**
- * @param {string} url
  * @param {string} route
+ * @returns {(pathname: string) => number|undefined}
+ */
+function createRoutePrefixMatcher (route) {
+  const routePrefix = route.replace(/\*$/u, '')
+
+  if (routePrefix === '/') {
+    return () => 0
+  }
+
+  if (routePrefix.includes(':') === false) {
+    return (pathname) => pathname.startsWith(routePrefix)
+      ? routePrefix.length
+      : undefined
+  }
+
+  const tokens = createRoutePrefixTokens(routePrefix)
+  return (pathname) => getRoutePrefixMatchLength(pathname, tokens)
+}
+
+/**
+ * @param {string} url
+ * @param {(pathname: string) => number|undefined} matchRoutePrefix
  * @returns {string|undefined}
  */
-function getPathnameForSend (url, route) {
+function getPathnameForSend (url, matchRoutePrefix) {
   const questionMark = url.indexOf('?')
   let pathname = questionMark === -1 ? url : url.slice(0, questionMark)
 
-  const routePrefix = route.replace(/\*$/u, '')
-
-  const prefixLength = getRoutePrefixMatchLength(pathname, routePrefix)
+  const prefixLength = matchRoutePrefix(pathname)
   if (prefixLength === undefined) {
     return
   }

--- a/index.js
+++ b/index.js
@@ -569,6 +569,52 @@ function getEncodingHeader (headers, checked) {
 }
 
 /**
+ * @param {string} pathname
+ * @param {string} routePrefix
+ * @returns {number|undefined}
+ */
+function getRoutePrefixMatchLength (pathname, routePrefix) {
+  if (routePrefix === '/') {
+    return 0
+  }
+
+  let pathnameIndex = 0
+  let routeIndex = 0
+
+  while (routeIndex < routePrefix.length) {
+    const routeChar = routePrefix[routeIndex]
+
+    if (routeChar === ':') {
+      routeIndex++
+
+      while (routeIndex < routePrefix.length && routePrefix[routeIndex] !== '/') {
+        routeIndex++
+      }
+
+      const segmentStart = pathnameIndex
+      while (pathnameIndex < pathname.length && pathname[pathnameIndex] !== '/') {
+        pathnameIndex++
+      }
+
+      if (pathnameIndex === segmentStart) {
+        return
+      }
+
+      continue
+    }
+
+    if (pathnameIndex >= pathname.length || pathname[pathnameIndex] !== routeChar) {
+      return
+    }
+
+    pathnameIndex++
+    routeIndex++
+  }
+
+  return pathnameIndex
+}
+
+/**
  * @param {string} url
  * @param {string} route
  * @returns {string|undefined}
@@ -581,11 +627,12 @@ function getPathnameForSend (url, route) {
     ? route.slice(0, -1)
     : route
 
-  if (routePrefix !== '/' && !pathname.startsWith(routePrefix)) {
+  const prefixLength = getRoutePrefixMatchLength(pathname, routePrefix)
+  if (prefixLength === undefined) {
     return
   }
 
-  pathname = pathname.slice(routePrefix.length)
+  pathname = pathname.slice(prefixLength)
 
   if (pathname === '') {
     pathname = '/'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
     "test:unit": "borp -C --check-coverage --lines 100",
-    "example": "node example/server.js"
+    "example": "node example/server.js",
+    "example:benchmark": "node example/server-benchmark.js"
   },
   "repository": {
     "type": "git",
@@ -68,6 +69,7 @@
   "devDependencies": {
     "@fastify/compress": "^8.0.0",
     "@types/node": "^25.0.3",
+    "autocannon": "^8.0.0",
     "borp": "^1.0.0",
     "c8": "^11.0.0",
     "concat-stream": "^2.0.0",

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -3695,6 +3695,41 @@ test('wildcard handler falls back to not found when the wildcard remainder is ma
   t.assert.deepStrictEqual(notFoundCalled, true)
 })
 
+test('wildcard handler falls back to not found when a literal segment after a param does not match', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  let wildcardHandler
+
+  fastify.addHook('onRoute', (route) => {
+    if (route.url === '/app/:version/public/*') {
+      wildcardHandler = route.handler
+    }
+  })
+
+  fastify.register(fastifyStatic, {
+    root: path.join(__dirname, '/static'),
+    prefix: '/app/:version/public'
+  })
+
+  t.after(() => fastify.close())
+
+  await fastify.ready()
+  t.assert.ok(wildcardHandler)
+
+  let notFoundCalled = false
+  await wildcardHandler({
+    raw: { url: '/app/1.2.3/private/index.css' },
+    routeOptions: { url: '/app/:version/public/*' }
+  }, {
+    callNotFound () {
+      notFoundCalled = true
+    }
+  })
+
+  t.assert.deepStrictEqual(notFoundCalled, true)
+})
+
 test('does not serve static files with encoded path separators', async (t) => {
   t.plan(4)
 
@@ -3771,6 +3806,30 @@ test('serves wildcard files when prefix contains a route param', async (t) => {
   t.assert.deepStrictEqual(response.statusCode, 200)
   t.assert.deepStrictEqual(response.headers['content-type'], 'text/css; charset=utf-8')
   t.assert.deepStrictEqual(response.body, fs.readFileSync(path.join(__dirname, '/static/index.css'), 'utf8'))
+})
+
+test('serves wildcard index files when a param prefix uses prefixAvoidTrailingSlash', async (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  t.after(() => fastify.close())
+
+  fastify.register(fastifyStatic, {
+    root: path.join(__dirname, '/static'),
+    prefix: '/app/:version',
+    prefixAvoidTrailingSlash: true,
+    decorateReply: false
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/app/1.2.3'
+  })
+
+  t.assert.deepStrictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(response.headers['content-type'], 'text/html; charset=utf-8')
+  t.assert.deepStrictEqual(response.body, fs.readFileSync(path.join(__dirname, '/static/index.html'), 'utf8'))
 })
 
 test('content-length in head route should not return zero when using wildcard', async t => {

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -6,7 +6,6 @@ const path = require('node:path')
 const fs = require('node:fs')
 const url = require('node:url')
 const http = require('node:http')
-const Module = require('node:module')
 const { test } = require('node:test')
 const Fastify = require('fastify')
 const compress = require('@fastify/compress')
@@ -80,16 +79,6 @@ if (typeof Promise.withResolvers === 'undefined') {
     })
     return { promise, resolve: promiseResolve, reject: promiseReject }
   }
-}
-
-function loadInternalPathnameForSend () {
-  const modulePath = require.resolve('../index.js')
-  const source = fs.readFileSync(modulePath, 'utf8') + '\nmodule.exports.__getPathnameForSend = getPathnameForSend\n'
-  const testModule = new Module(modulePath)
-  testModule.filename = modulePath
-  testModule.paths = module.paths
-  testModule._compile(source, modulePath)
-  return testModule.exports.__getPathnameForSend
 }
 
 test('register /static prefixAvoidTrailingSlash', async t => {
@@ -3601,18 +3590,6 @@ test(
   }
 )
 
-test('getPathnameForSend returns undefined for mismatched and malformed routes', (t) => {
-  t.plan(5)
-
-  const getPathnameForSend = loadInternalPathnameForSend()
-
-  t.assert.deepStrictEqual(getPathnameForSend('/nested/public/index.css', '/public/*'), undefined)
-  t.assert.deepStrictEqual(getPathnameForSend('/static/%E0%A4%A', '/static/*'), undefined)
-  t.assert.deepStrictEqual(getPathnameForSend('/static/index.css', '/static'), '/index.css')
-  t.assert.deepStrictEqual(getPathnameForSend('/app/1.2.3/index.css', '/app/:version/*'), '/index.css')
-  t.assert.deepStrictEqual(getPathnameForSend('/app//index.css', '/app/:version/*'), undefined)
-})
-
 test('wildcard handler falls back to not found when the raw url does not match the route prefix', async (t) => {
   t.plan(2)
 
@@ -3636,9 +3613,79 @@ test('wildcard handler falls back to not found when the raw url does not match t
   t.assert.ok(wildcardHandler)
 
   let notFoundCalled = false
-  wildcardHandler({
+  await wildcardHandler({
     raw: { url: '/nested/static/index.css' },
     routeOptions: { url: '/static/*' }
+  }, {
+    callNotFound () {
+      notFoundCalled = true
+    }
+  })
+
+  t.assert.deepStrictEqual(notFoundCalled, true)
+})
+
+test('wildcard handler falls back to not found when a param segment is empty', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  let wildcardHandler
+
+  fastify.addHook('onRoute', (route) => {
+    if (route.url === '/app/:version/*') {
+      wildcardHandler = route.handler
+    }
+  })
+
+  fastify.register(fastifyStatic, {
+    root: path.join(__dirname, '/static'),
+    prefix: '/app/:version'
+  })
+
+  t.after(() => fastify.close())
+
+  await fastify.ready()
+  t.assert.ok(wildcardHandler)
+
+  let notFoundCalled = false
+  await wildcardHandler({
+    raw: { url: '/app//index.css' },
+    routeOptions: { url: '/app/:version/*' }
+  }, {
+    callNotFound () {
+      notFoundCalled = true
+    }
+  })
+
+  t.assert.deepStrictEqual(notFoundCalled, true)
+})
+
+test('wildcard handler falls back to not found when the wildcard remainder is malformed', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  let wildcardHandler
+
+  fastify.addHook('onRoute', (route) => {
+    if (route.url === '/app/:version/*') {
+      wildcardHandler = route.handler
+    }
+  })
+
+  fastify.register(fastifyStatic, {
+    root: path.join(__dirname, '/static'),
+    prefix: '/app/:version'
+  })
+
+  t.after(() => fastify.close())
+
+  await fastify.ready()
+  t.assert.ok(wildcardHandler)
+
+  let notFoundCalled = false
+  await wildcardHandler({
+    raw: { url: '/app/1.2.3/%E0%A4%A' },
+    routeOptions: { url: '/app/:version/*' }
   }, {
     callNotFound () {
       notFoundCalled = true

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -3602,13 +3602,15 @@ test(
 )
 
 test('getPathnameForSend returns undefined for mismatched and malformed routes', (t) => {
-  t.plan(3)
+  t.plan(5)
 
   const getPathnameForSend = loadInternalPathnameForSend()
 
   t.assert.deepStrictEqual(getPathnameForSend('/nested/public/index.css', '/public/*'), undefined)
   t.assert.deepStrictEqual(getPathnameForSend('/static/%E0%A4%A', '/static/*'), undefined)
   t.assert.deepStrictEqual(getPathnameForSend('/static/index.css', '/static'), '/index.css')
+  t.assert.deepStrictEqual(getPathnameForSend('/app/1.2.3/index.css', '/app/:version/*'), '/index.css')
+  t.assert.deepStrictEqual(getPathnameForSend('/app//index.css', '/app/:version/*'), undefined)
 })
 
 test('wildcard handler falls back to not found when the raw url does not match the route prefix', async (t) => {
@@ -3694,6 +3696,29 @@ test('serves wildcard files when registered in an encapsulated context', async (
   const response = await fastify.inject({
     method: 'GET',
     url: '/nested/public/index.css'
+  })
+
+  t.assert.deepStrictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(response.headers['content-type'], 'text/css; charset=utf-8')
+  t.assert.deepStrictEqual(response.body, fs.readFileSync(path.join(__dirname, '/static/index.css'), 'utf8'))
+})
+
+test('serves wildcard files when prefix contains a route param', async (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+
+  t.after(() => fastify.close())
+
+  fastify.register(fastifyStatic, {
+    root: path.join(__dirname, '/static'),
+    prefix: '/app/:version',
+    decorateReply: false
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/app/1.2.3/index.css'
   })
 
   t.assert.deepStrictEqual(response.statusCode, 200)


### PR DESCRIPTION
## Problem

`@fastify/static` resolves wildcard paths from the raw URL to avoid decoding encoded path separators too early.

That logic currently assumes the route prefix is a literal string, so prefixes that contain Fastify params like `/app/:version` never match the raw pathname. As a result, valid static requests fall through to `reply.callNotFound()` and return 404.

Closes #575.

## Solution

- match wildcard route prefixes segment-by-segment instead of using a literal `startsWith()` check
- treat `:params` as one pathname segment when deriving the wildcard remainder
- keep using the raw URL + `decodeURI()` flow so encoded separator protection remains intact
- add regression coverage for both the helper and the full wildcard static route

## Testing

- `npm test`
- `npm run lint`
