### PR TITLE
fix: propagate return value from fastify.errorHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ async function fastifyStatic (fastify, opts) {
         return
       }
 
-      fastify.errorHandler(error, request, reply)
+      return fastify.errorHandler(error, request, reply)
     }
   }
 

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -2637,6 +2637,43 @@ test('routes should fallback to default errorHandler', async t => {
   })
 })
 
+test('routes should propagate return value from async custom errorHandler', async t => {
+  t.plan(3)
+
+  const pluginOptions = {
+    root: path.join(__dirname, '/static'),
+    prefix: '/static/'
+  }
+
+  const fastify = Fastify()
+
+  // An async error handler that returns its payload (without an explicit
+  // reply.send) relies on Fastify awaiting the returned promise. If
+  // @fastify/static does not propagate the return value of
+  // fastify.errorHandler(), the promise is dropped and the reply never
+  // resolves with the customized body.
+  fastify.setErrorHandler(async function (_error, _request, reply) {
+    reply.code(418).type('text/plain')
+    return 'handled by return value'
+  })
+
+  fastify.addHook('onRoute', function (routeOptions) {
+    routeOptions.preHandler = (_request, _reply, done) => {
+      const fakeError = new Error()
+      fakeError.code = 'SOMETHING_ELSE'
+      done(fakeError)
+    }
+  })
+
+  fastify.register(fastifyStatic, pluginOptions)
+  t.after(() => fastify.close())
+
+  const response = await fastify.inject({ method: 'GET', url: '/static/index.html' })
+  t.assert.deepStrictEqual(response.statusCode, 418)
+  t.assert.ok(response.headers['content-type'].startsWith('text/plain'))
+  t.assert.deepStrictEqual(response.body, 'handled by return value')
+})
+
 test('percent encoded URLs in glob mode', async (t) => {
   t.plan(3)
 


### PR DESCRIPTION
Fixes #581.

## Problem

The wrapper `errorHandler` registered on the static routes calls
`fastify.errorHandler(error, request, reply)` but discards its return
value (`index.js:79`).

That breaks custom error handlers that rely on Fastify's normal contract
of returning a value (or a Promise) instead of calling `reply.send`
themselves. In particular, an `async` error handler that returns its
payload never resolves the reply, because the dropped promise is never
awaited by Fastify.

Vanilla Fastify routes propagate that return value, so this was a
behavioral discrepancy specific to `@fastify/static`.

## Fix

Return the value from `fastify.errorHandler(...)` so the application's
error handler can short-circuit / transform the reply exactly like it
would on a non-static route. One-line change.

## Tests

Added a focused regression test in `test/static.test.js` that:

- Registers an `async` `setErrorHandler` returning its payload (without
  calling `reply.send`).
- Triggers an error from a `preHandler` so the static route's wrapper
  `errorHandler` runs.
- Asserts the status code, content-type, and body returned by the user's
  error handler reach the client.

Without the fix this test times out (the dropped promise never resolves
the reply). With the fix it passes.

## Checks

- `npm test` — 320/320 passing, 100% line coverage retained.
- `npm run lint` — clean.