### PR TITLE
refactor: replace glob dependency with custom glob using node:fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const path = require('node:path')
 const { fileURLToPath } = require('node:url')
 const { statSync } = require('node:fs')
-const { glob } = require('glob')
+const { glob } = require('./lib/glob')
 const fp = require('fastify-plugin')
 const send = require('@fastify/send')
 const encodingNegotiator = require('@fastify/accept-negotiator')

--- a/lib/glob.js
+++ b/lib/glob.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const fs = require('node:fs/promises')
+const path = require('node:path')
+
+function globToRegex (pattern) {
+  let p = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  p = p.replace(/\*\*\//g, '___GLOBSTAR___')
+  p = p.replace(/\*\*/g, '.*')
+  p = p.replace(/\*/g, '[^/]*')
+  p = p.replace(/___GLOBSTAR___/g, '(?:.*/)?')
+  return new RegExp('^' + p + '$')
+}
+
+function isIgnored(relativePath, ignorePatterns) {
+  const patterns = [].concat(ignorePatterns)
+  return patterns.some(pattern => globToRegex(pattern).test(relativePath))
+}
+
+async function findFiles (dir, opts, baseDir = dir) {
+  const files = []
+  let list
+  try {
+    list = await fs.readdir(dir, { withFileTypes: true })
+  } catch (err) {
+    return files
+  }
+
+  for (const entry of list) {
+    const fullPath = path.join(dir, entry.name)
+    const relativePath = path.relative(baseDir, fullPath).split(path.win32.sep).join(path.posix.sep)
+
+    const isDotFile = entry.name.startsWith('.')
+    if (isDotFile && !opts.serveDotFiles) {
+      continue
+    }
+
+    if (opts.globIgnore && isIgnored(relativePath, opts.globIgnore)) {
+      continue
+    }
+
+    let isDirectory = entry.isDirectory()
+    let isFile = entry.isFile()
+
+    if (entry.isSymbolicLink()) {
+      try {
+        const stat = await fs.stat(fullPath)
+        isDirectory = stat.isDirectory()
+        isFile = stat.isFile()
+      } catch (err) {
+        continue
+      }
+    }
+
+    if (isDirectory) {
+      files.push(...(await findFiles(fullPath, opts, baseDir)))
+    } else if (isFile) {
+      files.push(relativePath)
+    }
+  }
+  return files
+}
+
+async function glob (pattern, options, cb) {
+  if (typeof options === 'function') {
+    cb = options
+    options = {}
+  }
+  const opts = {
+    serveDotFiles: options.dot,
+    globIgnore: options.ignore
+  }
+
+  if (typeof cb === 'function') {
+    findFiles(options.cwd, opts).then(
+      files => cb(null, files),
+      err => cb(err)
+    )
+    return
+  }
+
+  return findFiles(options.cwd, opts)
+}
+
+module.exports = { glob }

--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
     "@fastify/send": "^4.0.0",
     "content-disposition": "^1.0.1",
     "fastify-plugin": "^5.0.0",
-    "fastq": "^1.17.1",
-    "glob": "^13.0.0"
+    "fastq": "^1.17.1"
   },
   "devDependencies": {
     "@fastify/compress": "^8.0.0",

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -2517,10 +2517,16 @@ test('if dotfiles are properly served according to plugin options', async (t) =>
 
 test('register with failing glob handler', async (t) => {
   const fastifyStatic = proxyquire.noCallThru()('../', {
-    glob: function globStub (_pattern, _options, cb) {
-      process.nextTick(function () {
-        return cb(new Error('mock glob error'))
-      })
+    './lib/glob': {
+      glob: function globStub (_pattern, _options, cb) {
+        if (typeof cb === 'function') {
+          process.nextTick(function () {
+            cb(new Error('mock glob error'))
+          })
+          return
+        }
+        return Promise.reject(new Error('mock glob error'))
+      }
     }
   })
 
@@ -4148,5 +4154,34 @@ test('register with wildcard false and globIgnore', async t => {
     t.assert.ok(!response.ok)
     t.assert.deepStrictEqual(response.status, 404)
     await response.text()
+  })
+})
+
+test('custom glob helper coverage', async (t) => {
+  const { glob } = require('../lib/glob')
+
+  await t.test('glob with non-existent directory returns empty array', async (t) => {
+    const files = await glob('**/**', { cwd: './non-existent-directory' })
+    t.assert.deepStrictEqual(files, [])
+  })
+
+  await t.test('glob with callback and options', async (t) => {
+    await new Promise((resolve, reject) => {
+      glob('**/**', { cwd: './non-existent-directory' }, (err, files) => {
+        if (err) return reject(err)
+        t.assert.deepStrictEqual(files, [])
+        resolve()
+      })
+    })
+  })
+
+  await t.test('glob with callback and no options', async (t) => {
+    await new Promise((resolve, reject) => {
+      glob('**/**', (err, files) => {
+        if (err) return reject(err)
+        t.assert.deepStrictEqual(files, [])
+        resolve()
+      })
+    })
   })
 })


### PR DESCRIPTION
This PR removes the external `glob` dependency to reduce the package footprint, resolving issue #551.

Since Node's native `fs.promises.glob` has some limitations (like not following symlinked directories and inconsistent globstar pattern behavior on certain Node versions), we implement a small, robust custom directory walker in `lib/glob.js` that mimics the expected interface.

Changes:
1. Implemented a zero-dependency recursive directory walker in `lib/glob.js` with support for `globIgnore` pattern-matching, dotfiles, and symlinks.
2. Updated `index.js` to require `./lib/glob` instead of `glob` and removed the dependency from `package.json`.
3. Updated the `proxyquire` mock in the tests to stub `./lib/glob` instead of `glob`, and added additional test cases to cover the callback/promise patterns and error cases of the custom glob utility to achieve 100% code coverage.