### PR TITLE
feat: support rendering JSON dir lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ Default: `json`
 Options: `html`, `json`
 
 Directory list can be in `html` format; in that case, `list.render` function is required.
+Directory list in `json` format can also use `list.render` to customize the JSON response.
+When `list.render` is omitted, the JSON response is controlled by `list.jsonFormat`.
+The `list.render` function receives `(dirs, files, format)`, where `format` is `html` or `json`.
 
 This option can be overridden by the URL parameter `format`. Options are `html` and `json`.
 
@@ -336,6 +339,26 @@ fastify.register(require('@fastify/static'), {
 </body></html>
 `
       },
+  }
+})
+```
+
+JSON render example:
+
+```js
+fastify.register(require('@fastify/static'), {
+  root: path.join(__dirname, 'public'),
+  prefix: '/public/',
+  list: {
+    format: 'json',
+    render: (dirs, files) => {
+      return {
+        dirs: dirs.map(dir => dir.name),
+        images: files
+          .filter(file => file.name.endsWith('.png'))
+          .map(file => ({ name: file.name, href: file.href }))
+      }
+    }
   }
 })
 ```

--- a/lib/dirList.js
+++ b/lib/dirList.js
@@ -129,7 +129,13 @@ const dirList = {
     }
 
     const format = reply.request.query.format || options.format
+    const renderFormat = format === 'html' ? 'html' : 'json'
     if (format !== 'html') {
+      if (typeof options.render === 'function' && options.format !== 'html') {
+        await reply.send(dirList.render(entries, route, prefix, options, renderFormat))
+        return
+      }
+
       if (options.jsonFormat !== 'extended') {
         const nameEntries = { dirs: [], files: [] }
         entries.dirs.forEach(entry => nameEntries.dirs.push(entry.name))
@@ -142,10 +148,24 @@ const dirList = {
       return
     }
 
-    const html = options.render(
-      entries.dirs.map(entry => dirList.htmlInfo(entry, route, prefix, options)),
-      entries.files.map(entry => dirList.htmlInfo(entry, route, prefix, options)))
+    const html = dirList.render(entries, route, prefix, options, renderFormat)
     await reply.type('text/html').send(html)
+  },
+
+  /**
+   * render directory entries
+   * @param {ReturnType<typeof dirList.list>} entries directory list entries
+   * @param {string} route request route
+   * @param {string} prefix static prefix
+   * @param {(ListOptionsJsonFormat | ListOptionsHtmlFormat)} options
+   * @param {'html' | 'json'} format response format
+   * @return {unknown}
+   */
+  render: function (entries, route, prefix, options, format) {
+    return options.render(
+      entries.dirs.map(entry => dirList.htmlInfo(entry, route, prefix, options)),
+      entries.files.map(entry => dirList.htmlInfo(entry, route, prefix, options)),
+      format)
   },
 
   /**

--- a/test/dir-list.test.js
+++ b/test/dir-list.test.js
@@ -497,6 +497,50 @@ test('dir list json format - extended info', async t => {
   })
 })
 
+test('dir list json format - render', async t => {
+  t.plan(1)
+
+  const options = {
+    root: path.join(__dirname, '/static'),
+    prefix: '/public',
+    prefixAvoidTrailingSlash: true,
+    list: {
+      format: 'json',
+      names: ['index', 'index.json', '/'],
+      render (dirs, files) {
+        return {
+          dirs: dirs.map(dir => dir.name),
+          images: files
+            .filter(file => file.name.endsWith('.jpg'))
+            .map(file => ({ name: file.name, href: file.href }))
+        }
+      }
+    }
+  }
+  const route = '/public/shallow/'
+  const content = {
+    dirs: ['empty'],
+    images: [
+      {
+        name: 'sample.jpg',
+        href: '/public/shallow/sample.jpg'
+      }
+    ]
+  }
+
+  await helper.arrange(t, options, async (url) => {
+    await t.test(route, async t => {
+      t.plan(4)
+
+      const response = await fetch(url + route)
+      t.assert.ok(response.ok)
+      t.assert.deepStrictEqual(response.status, 200)
+      t.assert.deepStrictEqual(await response.json(), content)
+      t.assert.ok(response.headers.get('content-type').includes('application/json'))
+    })
+  })
+})
+
 test('json format with url parameter format', async t => {
   t.plan(12)
 
@@ -506,8 +550,15 @@ test('json format with url parameter format', async t => {
     index: false,
     list: {
       format: 'json',
-      render () {
-        return 'html'
+      render (dirs, files, format) {
+        if (format === 'html') {
+          return 'html'
+        }
+
+        return {
+          dirs: dirs.map(dir => dir.name),
+          files: files.map(file => file.name)
+        }
       }
     }
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -44,8 +44,14 @@ declare namespace fastifyStatic {
     stats: Stats;
   }
 
+  export type ListFormat = 'html' | 'json'
+
   export interface ListRender {
-    (dirs: ListDir[], files: ListFile[]): string;
+    (dirs: ListDir[], files: ListFile[], format?: ListFormat): string;
+  }
+
+  export interface ListJsonRender {
+    (dirs: ListDir[], files: ListFile[], format?: ListFormat): unknown;
   }
 
   export interface ListOptions {
@@ -57,7 +63,7 @@ declare namespace fastifyStatic {
   export interface ListOptionsJsonFormat extends ListOptions {
     format: 'json';
     // Required when the URL parameter `format=html` exists
-    render?: ListRender;
+    render?: ListJsonRender;
   }
 
   export interface ListOptionsHtmlFormat extends ListOptions {

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -92,6 +92,15 @@ expect<FastifyStaticOptions>()
   .type.toBeAssignableFrom({
     root: '',
     list: {
+      format: 'json' as const,
+      render: () => ({ files: [] })
+    }
+  })
+
+expect<FastifyStaticOptions>()
+  .type.toBeAssignableFrom({
+    root: '',
+    list: {
       format: 'html' as const,
       render: () => ''
     }


### PR DESCRIPTION
## Summary
- allow JSON directory listings to use `list.render` when the list is configured for JSON/default JSON
- pass the selected `html`/`json` format to render callbacks
- update docs, runtime tests, and TypeScript coverage

Fixes #221

## Testing
- `node --test --test-name-pattern "dir list json format - render|json format with url parameter format|html format with url parameter format" test\dir-list.test.js`
- `npm.cmd run lint`
- `npm.cmd run test:typescript`

Note: `npm.cmd run test:unit` was not clean on this Windows checkout because existing symlink fixtures are checked out as regular files locally (`should follow symbolic link without wildcard`, plus dir-list expectations including `no-link`).
