### PR TITLE
fix!: allow setHeaders to override send headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ A flag that defines if the fastify route hide-schema attribute is hidden or not.
 Default: `undefined`
 
 A function to set custom headers on the response. Alterations to the headers
-must be done synchronously. The function is called as `fn(res, path, stat)`,
+must be done synchronously. The function is called as `fn(reply, path, stat)`,
 with the arguments:
 
-- `res` The response object.
+- `reply` The fastify Reply object.
 - `path` The path of the file that is being sent.
 - `stat` The stat object of the file that is being sent.
 

--- a/index.js
+++ b/index.js
@@ -404,8 +404,8 @@ async function fastifyStatic (fastify, opts) {
         // otherwise use send provided status code
         const newStatusCode = reply.statusCode !== 200 ? reply.statusCode : statusCode
         reply.code(newStatusCode)
-        setHeaders?.(reply.raw, metadata.path, metadata.stat)
         reply.headers(headers)
+        setHeaders?.(reply, metadata.path, metadata.stat)
         if (encoding) {
           reply.header('content-type', getContentType(pathname))
           reply.header('content-encoding', encoding)

--- a/test/static.test.js
+++ b/test/static.test.js
@@ -1290,13 +1290,14 @@ test('send options', (t) => {
 })
 
 test('setHeaders option', async (t) => {
-  t.plan(5 + GENERIC_RESPONSE_CHECK_COUNT)
+  t.plan(6 + GENERIC_RESPONSE_CHECK_COUNT)
 
   const pluginOptions = {
     root: path.join(__dirname, 'static'),
-    setHeaders: function (res, pathName) {
+    setHeaders: function (reply, pathName) {
       t.assert.deepStrictEqual(pathName, path.join(__dirname, 'static/index.html'))
-      res.setHeader('X-Test-Header', 'test')
+      reply.header('X-Test-Header', 'test')
+      reply.header('Cache-Control', 'public, immutable, max-age=2592000')
     }
   }
   const fastify = Fastify()
@@ -1312,6 +1313,7 @@ test('setHeaders option', async (t) => {
   t.assert.ok(response.ok)
   t.assert.deepStrictEqual(response.status, 200)
   t.assert.deepStrictEqual(response.headers.get('x-test-header'), 'test')
+  t.assert.deepStrictEqual(response.headers.get('cache-control'), 'public, immutable, max-age=2592000')
   t.assert.deepStrictEqual(await response.text(), indexContent)
   genericResponseChecks(t, response)
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,13 +15,6 @@ declare module 'fastify' {
 type FastifyStaticPlugin = FastifyPluginAsync<NonNullable<fastifyStatic.FastifyStaticOptions>>
 
 declare namespace fastifyStatic {
-  export interface SetHeadersResponse {
-    getHeader: FastifyReply['getHeader'];
-    setHeader: FastifyReply['header'];
-    readonly filename: string;
-    statusCode: number;
-  }
-
   export interface ExtendedInformation {
     fileCount: number;
     totalFileCount: number;
@@ -100,7 +93,7 @@ declare namespace fastifyStatic {
       prefixAvoidTrailingSlash?: boolean;
       decorateReply?: boolean;
       schemaHide?: boolean;
-      setHeaders?: (res: SetHeadersResponse, path: string, stat: Stats) => void;
+      setHeaders?: (reply: FastifyReply, path: string, stat: Stats) => void;
       redirect?: boolean;
       wildcard?: boolean;
       globIgnore?: string[];

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -1,6 +1,6 @@
-import fastify, { type FastifyInstance, type FastifyPluginAsync, type FastifyRequest, type FastifyReply } from 'fastify'
-import { type Server } from 'node:http'
+import fastify, { type FastifyInstance, type FastifyPluginAsync, type FastifyReply, type FastifyRequest } from 'fastify'
 import { type Stats } from 'node:fs'
+import { type Server } from 'node:http'
 import { expect } from 'tstyche'
 import * as fastifyStaticStar from '..'
 import fastifyStatic, {
@@ -50,11 +50,11 @@ const options: FastifyStaticOptions = {
   wildcard: true,
   globIgnore: ['**/*.private'],
   list: false,
-  setHeaders: (res, path, stat) => {
-    expect(res.filename).type.toBe<string>()
-    expect(res.statusCode).type.toBe<number>()
-    expect(res.getHeader('X-Test')).type.toBe<ReturnType<FastifyReply['getHeader']>>()
-    res.setHeader('X-Test', 'string')
+  setHeaders: (reply, path, stat) => {
+    expect(reply).type.toBe<FastifyReply>()
+    expect(reply.statusCode).type.toBe<number>()
+    expect(reply.getHeader('X-Test')).type.toBe<ReturnType<FastifyReply['getHeader']>>()
+    reply.header('X-Test', 'string')
 
     expect(path).type.toBe<string>()
 


### PR DESCRIPTION
Fixes #508

Breaking Changes
- Use `FastifyReply` instead of `HTTPResponse` in `setHeaders`.

Fixes
- Allows `setHeaders` to override the headers set by `send`.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
